### PR TITLE
chore(pipeline) ensure that production deployment reports its status

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -121,10 +121,10 @@ pipeline {
       }
       post {
         success {
-          recordDeployment('jenkins-infra', 'stories', env.GIT_COMMIT, 'success', "https://jenkins-is-the-way.netlify.app", "production")
+          recordDeployment('jenkins-infra', 'stories', env.GIT_COMMIT, 'success', 'https://jenkins-is-the-way.netlify.app', [environment: 'production'])
         }
         failure {
-          recordDeployment('jenkins-infra', 'stories', env.GIT_COMMIT, 'failure', "https://jenkins-is-the-way.netlify.app", "production")
+          recordDeployment('jenkins-infra', 'stories', env.GIT_COMMIT, 'failure', 'https://jenkins-is-the-way.netlify.app', [environment: 'production'])
         }
       }
     }


### PR DESCRIPTION
The call to `recordDeployment()` in the `post` block fails with the following message:

```
19:04:24  org.jenkinsci.plugins.scriptsecurity.sandbox.RejectedAccessException: Scripts not permitted to use method groovy.lang.GroovyObject invokeMethod java.lang.String java.lang.Object (org.jenkinsci.plugins.workflow.cps.CpsClosure2 recordDeployment java.lang.String java.lang.String java.lang.String java.lang.String java.lang.String java.lang.String)
```

=> the method signature is incorrect as per https://github.com/jenkins-infra/pipeline-library/blob/master/vars/recordDeployment.groovy#LL1C56-L1C66.

This PR fixes this issue (tested with a replay on infra.ci.jenkins.io)