### PR TITLE
stories.jenkins.io - update to remove form from intro

### DIFF
--- a/src/pages/all.jsx
+++ b/src/pages/all.jsx
@@ -39,8 +39,8 @@ const AllPage = () => {
                     <div className="col">
                         <h2>Tell Your Story</h2>
                         <p>&quot;Jenkins Is The Way&quot; is a global showcase of how developers and engineers are building, deploying, and automating great stuff with Jenkins.</p>
-                        <p>Share your story and we’ll send you a free Jenkins Is The Way T-Shirt.</p>
-                        <p>Our short form will capture details about your project’s goals and technical challenges, and the unique solutions you came up with using Jenkins.</p>
+                        <p>Share your story and we'll send you a free Jenkins Is The Way T-Shirt.</p>
+                        <p>Submit a pull request about your project's goals and technical challenges, and the unique solutions you came up with using Jenkins.</p>
                     </div>
                 </div>
                 <div className="row">


### PR DESCRIPTION
Since we are no longer using a form to capture user stories, the text has been changed to reflect the fact that users should submit pull requests to add their stories.