### PR TITLE
Switch to linux agents

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,7 +7,7 @@ pipeline {
   }
 
   agent {
-    label 'node'
+    label 'linux'
   }
 
   environment {


### PR DESCRIPTION
Currently, we don't provide agents with that label on public infra. I recommend we switch to generic linux runners. This PR should unblock my other PRs.