### PR TITLE
cleanup: delete Jenkinsfile_k8s

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -1,1 +1,0 @@
-Jenkinsfile


### PR DESCRIPTION
As the job configuration on infra.ci.jenkins.io is already specifying the Jenkinsfile path, this PR removes the unused simlink from Jenkinsfile to Jenkinsfile_k8s.

https://github.com/jenkins-infra/kubernetes-management/blob/2cd45da2352361481c0b242b4b5bcfae19e9a602/config/jenkins-jobs_infra.ci.jenkins.io.yaml#L417C37-L417C37

