### PR TITLE
Update jenkins-is-the-way-for-networkupstools as of mid-2024

### DIFF
--- a/src/user-story/jenkins-is-the-way-for-networkupstools/index.yaml
+++ b/src/user-story/jenkins-is-the-way-for-networkupstools/index.yaml
@@ -69,8 +69,10 @@ body_content:
       everywhere its iterations had to be regularly built everywhere.
     - |-
       Eventually the reign of free Travis CI ended, and NUT got VMs for a CI
-      farm sponsored by [Fosshost.org](https://fosshost.org/) to proceed with
-      the multi-platform testing.
+      farm sponsored by [Fosshost.org](https://fosshost.org/) and later by
+      [DigitalOcean](https://www.digitalocean.com/?refcode=d2fbf2b9e082&utm_campaign=Referral_Invite&utm_medium=Referral_Program&utm_source=badge)
+      to proceed with the multi-platform testing.
+    - |-
       Using a custom Jenkins instance to take care of the project's codebase
       builds and make use of numerous operating systems in other VMs (as SSH
       Build Agents), as well as build agents contributed by community (e.g.
@@ -80,8 +82,8 @@ body_content:
       library which constructs a huge Map of parallel stages similar to a
       standard matrix build.
     - |-
-      However in this case, it is not the matrix definition fully dictating what
-      should be built, but rather the build agents are expected to report
+      However in this case, it is not the static matrix definition fully dictating
+      what should be built, but rather the build agents are expected to report
       capabilities with their labels -- such as which platform they run and what
       versions and implementations of toolkits are available to test with, and
       whether "everything" can be built or just certain profiles (not all OS
@@ -91,6 +93,13 @@ body_content:
       starts, the NUT Jenkinsfile (consumer of jenkins-dynamatrix library) can
       evaluate what it can build today -- based on currently known population of
       build agents, and so constructs the matrix for testing.
+    - |-
+      A sibling [https://github.com/networkupstools/jenkins-swarm-nutci](https://github.com/networkupstools/jenkins-swarm-nutci)
+      project is used on many of the build agents which can dial in to the NUT CI
+      farm and provide their services and capabilities (conveyed by the labels
+      which are part of their configuration), and includes some scripting for a
+      common configuration approach as well as for automated start-up on numerous
+      platforms. It might be usable "as is" or easily adapted by other projects.
     - |-
       This arrangement allows NUT to be built on a multitude of platforms such
       that common free CI platforms do not offer. It is possible to find ways to
@@ -105,7 +114,7 @@ body_content:
       the dozenth releases out recently, across a dozen hardware platforms (some
       in QEMU), and several revisions of C/C++ standard with and without GNU
       extensions. All in all, with recently regularly connected builders about
-      150 stages are prepared (some running several build scenarios as scripted
+      250 stages are prepared (some running several build scenarios as scripted
       inside, so roughly a thousand builds happen). Sometimes a nuance warning
       causes one of these scenarios to complain during PR builds -- on this or
       that OS, this or that compiler. It keeps us confident both that such
@@ -115,8 +124,8 @@ body_content:
       With the hundreds of builds succeeding without warnings -- reliably,
       repeatably, every time -- the floodgates for ingestion of long-standing
       PRs were open. Largest beasts included the dual-citizenship with
-      libusb-0.1 and libusb-1.x support (queued for 5 years) and revival of NUT
-      for Windows effort (queued for 9 years), confidently merged without
+      libusb-0.1 and libusb-1.x support (queued for 5 years) and revival of the
+      NUT for Windows effort (queued for 9 years), confidently merged without
       introducing warnings and regressions. The overwhelming majority of these
       builds happen on the custom "NUT CI" farm with Jenkins driving them. A few
       scenarios run on CircleCI and Appveyor to take advantage of some free FOSS


### PR DESCRIPTION
* Updated some wording and numbers.
* Added reference to DigitalOcean as the current sponsor of NUT CI farm.
* Added a paragraph about sibling jenkins-swarm project for agents that can dial in and proclaim their abilities, to be included in the dynamatrix for the next upcoming builds

NOTE: Not sure if the article timestamp must be updated in the heading?