### PR TITLE
Reintroduce "authored_by" Field in Map Popups

### DIFF
--- a/src/pages/map.jsx
+++ b/src/pages/map.jsx
@@ -28,6 +28,7 @@ const MapPage = () => {
         edges {
           node {
             map {
+              authored_by
               latitude
               longitude
               industries
@@ -132,6 +133,7 @@ const MapPage = () => {
                                 padding: '5px',
                               }}
                             >
+                              <dt>{story.map.authored_by}</dt>
                               <dt>{story.map.location}</dt>
                               <dt>
                                 {(

--- a/src/user-story/a-stable-projects-life/index.yaml
+++ b/src/user-story/a-stable-projects-life/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Konstantin Averkiev
   location: Belarus
   industries:
     - Information Technology

--- a/src/user-story/customers-digital-transformation/index.yaml
+++ b/src/user-story/customers-digital-transformation/index.yaml
@@ -26,6 +26,7 @@ metadata:
     - Yes
 quotes: []
 map:
+  authored_by: Alauda
   location: Beijing, China
   latitude: "39.9042"
   longitude: "116.4074"

--- a/src/user-story/jenkins-is-the-way-for-networkupstools/index.yaml
+++ b/src/user-story/jenkins-is-the-way-for-networkupstools/index.yaml
@@ -30,6 +30,7 @@ metadata:
     - Yes
 quotes: []
 map:
+  authored_by: Konstantin Averkiev
   location: Prague, CZ
   latitude: "50.0755"
   longitude: "14.4378"

--- a/src/user-story/jenkins-is-the-way-to-automate-all-the-things/index.yaml
+++ b/src/user-story/jenkins-is-the-way-to-automate-all-the-things/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Christopher Duffy
   location: Florida, USA
   industries:
     - Technology

--- a/src/user-story/jenkins-is-the-way-to-automate-ci-cd-efficiently/index.yaml
+++ b/src/user-story/jenkins-is-the-way-to-automate-ci-cd-efficiently/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Bibek Sutradhar
   location: India
   industries:
     - Consulting

--- a/src/user-story/jenkins-is-the-way-to-build-robust-and-specific-pipelines/index.yaml
+++ b/src/user-story/jenkins-is-the-way-to-build-robust-and-specific-pipelines/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Alexandre Hiltcher
   location: France
   industries:
     - Information Technology

--- a/src/user-story/jenkins-is-the-way-to-create-an-awesome-pipeline/index.yaml
+++ b/src/user-story/jenkins-is-the-way-to-create-an-awesome-pipeline/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Amandep Singh
   location: India
   industries:
     - Telecomunications

--- a/src/user-story/jenkins-is-the-way-to-deliver-telecom-platforms-around-the-globe/index.yaml
+++ b/src/user-story/jenkins-is-the-way-to-deliver-telecom-platforms-around-the-globe/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Joana Carneiro
   location: Portugal
   industries:
     - Telecomunications

--- a/src/user-story/jenkins-is-the-way-to-devops-in-any-technology/index.yaml
+++ b/src/user-story/jenkins-is-the-way-to-devops-in-any-technology/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Jorge Hidalgo
   location: Spain
   industries:
     - Cloud Computing

--- a/src/user-story/jenkins-is-the-way-to-enable-teams-to-ship-software-swiftly/index.yaml
+++ b/src/user-story/jenkins-is-the-way-to-enable-teams-to-ship-software-swiftly/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Gaurav Nanda
   location: India
   industries:
     - Software Developement

--- a/src/user-story/jenkins-is-the-way-to-fintech-excellence/index.yaml
+++ b/src/user-story/jenkins-is-the-way-to-fintech-excellence/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Lara Evdokimova
   location: Russia
   industries:
     - Financial Services

--- a/src/user-story/jenkins-is-the-way-to-improve-solution-development/index.yaml
+++ b/src/user-story/jenkins-is-the-way-to-improve-solution-development/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Anthony Alberto Alcala Beltran
   location: Peru
   industries:
     - Information Technology

--- a/src/user-story/jenkins-is-the-way-to-revolutionize-loyalty-programs/index.yaml
+++ b/src/user-story/jenkins-is-the-way-to-revolutionize-loyalty-programs/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Gabriel Rosales
   location: Florida, USA
   industries:
     - Financial Services

--- a/src/user-story/jenkins-is-the-way-to-show-people-how-its-done/index.yaml
+++ b/src/user-story/jenkins-is-the-way-to-show-people-how-its-done/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Filipe Costa
   location: Portugal
   industries:
     - Information Technology

--- a/src/user-story/jenkins-is-the-way-to-transform-healthcare/index.yaml
+++ b/src/user-story/jenkins-is-the-way-to-transform-healthcare/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Ashutosh Pattanaik
   location: India
   industries:
     - Healthcare

--- a/src/user-story/jenkins-is-the-way-to-win/index.yaml
+++ b/src/user-story/jenkins-is-the-way-to-win/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Thomas Haver
   location: Ohio, USA
   industries:
     - Financial Services

--- a/src/user-story/to-a-streamlined-mortgage-industry/index.yaml
+++ b/src/user-story/to-a-streamlined-mortgage-industry/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Arman Chand
   location: India
   industries:
     - Financial Services - Mortgage

--- a/src/user-story/to-accelerate-automation-in-the-cloud/index.yaml
+++ b/src/user-story/to-accelerate-automation-in-the-cloud/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Gaurav Agarwal
   location: United Kingdom
   industries:
     - Logistics

--- a/src/user-story/to-achieve-a-stable-cicd-enterprise-solution/index.yaml
+++ b/src/user-story/to-achieve-a-stable-cicd-enterprise-solution/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Emil Vulkov
   location: Bulgaria
   industries:
     - Financial Services

--- a/src/user-story/to-achieve-accuracy/index.yaml
+++ b/src/user-story/to-achieve-accuracy/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Abhinav Dubey
   location: India
   industries:
     - DevOps & Machine Learning

--- a/src/user-story/to-add-spicy-flavors-to-muzkats-processes/index.yaml
+++ b/src/user-story/to-add-spicy-flavors-to-muzkats-processes/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Erik Woitschig
   location: Germany
   industries:
     - Advertising & Marketing

--- a/src/user-story/to-add-stability-to-the-overall-software-delivery-process/index.yaml
+++ b/src/user-story/to-add-stability-to-the-overall-software-delivery-process/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Ajit Gunge
   location: India
   industries:
     - Telecomunications

--- a/src/user-story/to-amazing-automation/index.yaml
+++ b/src/user-story/to-amazing-automation/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Mitchell Locktree
   location: Netherlands
   industries:
     - Semiconductors

--- a/src/user-story/to-automate-almost-anything-in-an-enterprise/index.yaml
+++ b/src/user-story/to-automate-almost-anything-in-an-enterprise/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Monish Ratanji
   location: California, USA
   industries:
     - Information Technology

--- a/src/user-story/to-automate-and-accelerate-application-deployment/index.yaml
+++ b/src/user-story/to-automate-and-accelerate-application-deployment/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Sridhar Kapidi
   location: Malaysia
   industries:
     - Information Technology

--- a/src/user-story/to-automate-and-improve/index.yaml
+++ b/src/user-story/to-automate-and-improve/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Andreas Schwarzkopf
   location: Germany
   industries:
     - Automotive

--- a/src/user-story/to-automate-anything-in-healthcare/index.yaml
+++ b/src/user-story/to-automate-anything-in-healthcare/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Vishal VR Gowda
   location: India
   industries:
     - Healthcare

--- a/src/user-story/to-automate-builds-and-tests/index.yaml
+++ b/src/user-story/to-automate-builds-and-tests/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Jayant Sikarwar
   location: India
   industries:
     - Financial Services

--- a/src/user-story/to-automate-continuous-delivery-pipelines/index.yaml
+++ b/src/user-story/to-automate-continuous-delivery-pipelines/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Jon Brohauge
   location: Denmark
   industries:
     - Insurance

--- a/src/user-story/to-automate-development-tasks/index.yaml
+++ b/src/user-story/to-automate-development-tasks/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Bilal Bailey
   location: Illinois, USA
   industries:
     - Manufacturing

--- a/src/user-story/to-automate-everything/index.yaml
+++ b/src/user-story/to-automate-everything/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Yazeed AL-Smadi
   location: Jordan
   industries:
     - Healthcare

--- a/src/user-story/to-automate-noc-operations/index.yaml
+++ b/src/user-story/to-automate-noc-operations/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Alexander Leibzon
   location: Israel
   industries:
     - Advertising & Marketing

--- a/src/user-story/to-automate-test-execution-and-manage-distributed-systems/index.yaml
+++ b/src/user-story/to-automate-test-execution-and-manage-distributed-systems/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Gábor Barna
   location: Hungary
   industries:
     - Telecomunications

--- a/src/user-story/to-automate-testing-reporting-and-scaling/index.yaml
+++ b/src/user-story/to-automate-testing-reporting-and-scaling/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Anand Bhagwat
   location: India
   industries:
     - Artificial Intelligence (AI)

--- a/src/user-story/to-automate-the-boring-stuff/index.yaml
+++ b/src/user-story/to-automate-the-boring-stuff/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Mohamad Farhan bin Zainudin, Cloud Engineer
   location: Malaysia
   industries:
     - DevOps as a Service

--- a/src/user-story/to-automate-the-future-for-developers/index.yaml
+++ b/src/user-story/to-automate-the-future-for-developers/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Manasi Jha
   location: India
   industries:
     - Engineering

--- a/src/user-story/to-automate-the-lives-of-all-programmers-who-want-a-quality-product/index.yaml
+++ b/src/user-story/to-automate-the-lives-of-all-programmers-who-want-a-quality-product/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Diogo Alves de Almeida
   location: Brazil
   industries:
     - Logistics

--- a/src/user-story/to-automate-the-work/index.yaml
+++ b/src/user-story/to-automate-the-work/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Vilsi Jain
   location: India
   industries:
     - Technology

--- a/src/user-story/to-automate-the-world/index.yaml
+++ b/src/user-story/to-automate-the-world/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Sebastien Sirtoli
   location: Belgium
   industries:
     - Transport

--- a/src/user-story/to-automate-your-job-and-transform-your-life/index.yaml
+++ b/src/user-story/to-automate-your-job-and-transform-your-life/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Damian Zermeño
   location: Mexico
   industries:
     - Electronics Manufacturing

--- a/src/user-story/to-awesome-delivery-with-accurate-ci-cd-setup/index.yaml
+++ b/src/user-story/to-awesome-delivery-with-accurate-ci-cd-setup/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Ashish Kumar Das
   location: India
   industries:
     - Telecomunications

--- a/src/user-story/to-bring-brazils-freight-workers-to-the-21st-century/index.yaml
+++ b/src/user-story/to-bring-brazils-freight-workers-to-the-21st-century/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Diogo Almeida
   location: Brazil
   industries:
     - Logistics

--- a/src/user-story/to-bring-our-community-together/index.yaml
+++ b/src/user-story/to-bring-our-community-together/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Aidan Moriarty
   location: France
   industries:
     - Digital Technology Provider

--- a/src/user-story/to-build-a-scalable-ci-cd-orchestration-platform/index.yaml
+++ b/src/user-story/to-build-a-scalable-ci-cd-orchestration-platform/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Jeff Guzman
   location: Virginia, USA
   industries:
     - Financial Services

--- a/src/user-story/to-build-and-deliver-software/index.yaml
+++ b/src/user-story/to-build-and-deliver-software/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Joana Carneiro
   location: Israel
   industries:
     - Defense Technology

--- a/src/user-story/to-build-and-maintain-even-the-most-complex-software-in-the-world/index.yaml
+++ b/src/user-story/to-build-and-maintain-even-the-most-complex-software-in-the-world/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Theodore Chaikalis
   location: Greece
   industries:
     - Government

--- a/src/user-story/to-build-and-release-faster/index.yaml
+++ b/src/user-story/to-build-and-release-faster/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Buvanesh Kumar
   location: India
   industries:
     - Technology

--- a/src/user-story/to-build-and-test-multiple-environments/index.yaml
+++ b/src/user-story/to-build-and-test-multiple-environments/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Emmanouil Katefidis
   location: Greece
   industries:
     - Cloud Computing

--- a/src/user-story/to-build-chat-bot-driven-declarative-pipelines-for-continuous-delivery/index.yaml
+++ b/src/user-story/to-build-chat-bot-driven-declarative-pipelines-for-continuous-delivery/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Prasanjit Singh
   location: United Arab Emirates
   industries:
     - Media & Entertainment

--- a/src/user-story/to-build-ci-cd-that-fits-advanced-and-unique-use-cases/index.yaml
+++ b/src/user-story/to-build-ci-cd-that-fits-advanced-and-unique-use-cases/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Ahmed AbouZaid
   location: Germany
   industries:
     - Business Process Modeling (BPM)

--- a/src/user-story/to-build-continuous-communities-in-your-business/index.yaml
+++ b/src/user-story/to-build-continuous-communities-in-your-business/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: James Wasson, Client Solutions Architect
   location: Oklahoma, USA
   industries:
     - Energy

--- a/src/user-story/to-build-for-the-future/index.yaml
+++ b/src/user-story/to-build-for-the-future/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Gregory Jacobs
   location: Wisconsin, USA
   industries:
     - Healthcare

--- a/src/user-story/to-build-industry-leading-log-management/index.yaml
+++ b/src/user-story/to-build-industry-leading-log-management/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Donald Morton
   location: Arkansas, USA
   industries:
     - Software Development

--- a/src/user-story/to-cast-magic-of-continuous-delivery-2/index.yaml
+++ b/src/user-story/to-cast-magic-of-continuous-delivery-2/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Oleg Tikhonov
   location: Israel
   industries:
     - Internet of Things (IoT)

--- a/src/user-story/to-cast-magic-of-continuous-delivery/index.yaml
+++ b/src/user-story/to-cast-magic-of-continuous-delivery/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Xuefeng Shi
   location: China
   industries:
     - E-commerce & Retail

--- a/src/user-story/to-completely-automate-your-ci-cd-workflow/index.yaml
+++ b/src/user-story/to-completely-automate-your-ci-cd-workflow/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Oscar Palacios
   location: Florida, USA
   industries:
     - Automotive

--- a/src/user-story/to-consistency/index.yaml
+++ b/src/user-story/to-consistency/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Shauna Wright
   location: Colorado, USA
   industries:
     - Aerospace

--- a/src/user-story/to-continuously-build-test-and-release-your-software/index.yaml
+++ b/src/user-story/to-continuously-build-test-and-release-your-software/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Omprakash Paliwal
   location: India
   industries:
     - Information Technology

--- a/src/user-story/to-cook-almost-everything-in-devops-world/index.yaml
+++ b/src/user-story/to-cook-almost-everything-in-devops-world/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Nilesh Attarde
   location: India
   industries:
     - Product Lifecycle Management (PLM)

--- a/src/user-story/to-create-a-computer-on-wheels/index.yaml
+++ b/src/user-story/to-create-a-computer-on-wheels/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Garima Singh
   location: India
   industries:
     - Education

--- a/src/user-story/to-create-collaboration-between-the-dev-and-the-ops-teams/index.yaml
+++ b/src/user-story/to-create-collaboration-between-the-dev-and-the-ops-teams/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Kuldeep Sharma
   location: India
   industries:
     - Financial Services

--- a/src/user-story/to-deliver-amazing-products-easily/index.yaml
+++ b/src/user-story/to-deliver-amazing-products-easily/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Chaitanya Dwivedi
   location: Texas, USA
   industries:
     - Semiconductors

--- a/src/user-story/to-deliver-our-new-releases-on-time/index.yaml
+++ b/src/user-story/to-deliver-our-new-releases-on-time/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Jason Shaw
   location: Canada
   industries:
     - Software Development

--- a/src/user-story/to-deliver/index.yaml
+++ b/src/user-story/to-deliver/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Tomas Valentukevicius
   location: Lithuania
   industries:
     - Telecomunications

--- a/src/user-story/to-deploy-a-truly-functional-and-efficient-system-to-manage-build-pipelines/index.yaml
+++ b/src/user-story/to-deploy-a-truly-functional-and-efficient-system-to-manage-build-pipelines/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Joseph Tole
   location: Canada
   industries:
     - Artificial Intelligence (AI)

--- a/src/user-story/to-develop-an-easy-lifestyle-for-developers/index.yaml
+++ b/src/user-story/to-develop-an-easy-lifestyle-for-developers/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Shivanshu Sharma
   location: India
   industries:
     - DevOps Automation

--- a/src/user-story/to-devsecops/index.yaml
+++ b/src/user-story/to-devsecops/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Canux Cheng
   location: China
   industries:
     - Network Security

--- a/src/user-story/to-do-ci-cd-right/index.yaml
+++ b/src/user-story/to-do-ci-cd-right/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Akhil Pradhan
   location: Texas, USA
   industries:
     - Automotive

--- a/src/user-story/to-do-things-quickly-simply-and-in-a-powerful-way/index.yaml
+++ b/src/user-story/to-do-things-quickly-simply-and-in-a-powerful-way/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Gabriel Ramis
   location: Portugal
   industries:
     - Travel

--- a/src/user-story/to-drink-coffee-all-day/index.yaml
+++ b/src/user-story/to-drink-coffee-all-day/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Alex Kondrashov
   location: Israel
   industries:
     - Education

--- a/src/user-story/to-drive-software-releases-from-manual-to-autopilot-mode/index.yaml
+++ b/src/user-story/to-drive-software-releases-from-manual-to-autopilot-mode/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Surendra Reddy
   location: India
   industries:
     - Education

--- a/src/user-story/to-easy-development/index.yaml
+++ b/src/user-story/to-easy-development/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Mohammad Hanif
   location: Indonesia
   industries:
     - Engineering

--- a/src/user-story/to-experiments-and-eternity/index.yaml
+++ b/src/user-story/to-experiments-and-eternity/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Eugene Starchenko
   location: Ukraine
   industries:
     - Consulting

--- a/src/user-story/to-explore-different-business-processes/index.yaml
+++ b/src/user-story/to-explore-different-business-processes/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Vlad Silverman
   location: California, USA
   industries:
     - Financial Services

--- a/src/user-story/to-facilitate-day-to-day-work/index.yaml
+++ b/src/user-story/to-facilitate-day-to-day-work/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Anti Asko
   location: France
   industries:
     - Research

--- a/src/user-story/to-faster-and-safer-shipping-to-clients/index.yaml
+++ b/src/user-story/to-faster-and-safer-shipping-to-clients/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Jorge Uztariz
   location: Colombia
   industries:
     - Software Developement

--- a/src/user-story/to-faster-product-release/index.yaml
+++ b/src/user-story/to-faster-product-release/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Swaraj Dutta
   location: India
   industries:
     - Information Technology

--- a/src/user-story/to-finally-bring-a-retail-giant-into-the-21st-century/index.yaml
+++ b/src/user-story/to-finally-bring-a-retail-giant-into-the-21st-century/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: John Pope
   location: United Kingdom
   industries:
     - E-commerce & Retail

--- a/src/user-story/to-fulfill-every-build-wish-we-might-come-up-with/index.yaml
+++ b/src/user-story/to-fulfill-every-build-wish-we-might-come-up-with/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Marco de Krijger
   location: Netherlands
   industries:
     - Consulting

--- a/src/user-story/to-get-stuff-done/index.yaml
+++ b/src/user-story/to-get-stuff-done/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Kalin Dimitrov
   location: Sofia, Bulgaria
   industries:
     - Financial Services

--- a/src/user-story/to-give-nitro-to-builds-and-deployments/index.yaml
+++ b/src/user-story/to-give-nitro-to-builds-and-deployments/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Githin Joseph
   location: India
   industries:
     - Travel

--- a/src/user-story/to-guaranteed-quality-for-your-devices/index.yaml
+++ b/src/user-story/to-guaranteed-quality-for-your-devices/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: François Mockers
   location: France
   industries:
     - Internet of Things (IoT)

--- a/src/user-story/to-happy-developers/index.yaml
+++ b/src/user-story/to-happy-developers/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Alan Waite
   location: Pennsylvania, USA
   industries:
     - Robotics

--- a/src/user-story/to-help-developers-properly-do-their-jobs/index.yaml
+++ b/src/user-story/to-help-developers-properly-do-their-jobs/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Christophe Michaux
   location: France
   industries:
     - Financial Services

--- a/src/user-story/to-help-teams-focus-on-what-is-really-important/index.yaml
+++ b/src/user-story/to-help-teams-focus-on-what-is-really-important/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Eduardo Mandry
   location: Chile
   industries:
     - Financial Services

--- a/src/user-story/to-improve-payment-systems/index.yaml
+++ b/src/user-story/to-improve-payment-systems/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Adam Szatyin
   location: Hungary
   industries:
     - Financial Services

--- a/src/user-story/to-integrate-the-thoughts/index.yaml
+++ b/src/user-story/to-integrate-the-thoughts/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Gyan Gupta
   location: India
   industries:
     - Automotive

--- a/src/user-story/to-keep-ibm-always-on/index.yaml
+++ b/src/user-story/to-keep-ibm-always-on/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Alec Rieger
   location: North Carolina, USA
   industries:
     - Infrastructure

--- a/src/user-story/to-keep-the-world-spinning/index.yaml
+++ b/src/user-story/to-keep-the-world-spinning/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Julio Conchas
   location: Mexico
   industries:
     - Cloud Computing

--- a/src/user-story/to-kill-em-with-agile/index.yaml
+++ b/src/user-story/to-kill-em-with-agile/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Ferdila Rahmi
   location: Indonesia
   industries:
     - Defense Technology

--- a/src/user-story/to-link-deliverability-and-quality/index.yaml
+++ b/src/user-story/to-link-deliverability-and-quality/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Aurelien Dorey
   location: France
   industries:
     - Energy

--- a/src/user-story/to-long-term-automation-strategies/index.yaml
+++ b/src/user-story/to-long-term-automation-strategies/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Bhargav Murarisetty
   location: India
   industries:
     - Software Developement

--- a/src/user-story/to-make-a-project-successful-without-wasting-time-on-unwanted-manual-efforts-2/index.yaml
+++ b/src/user-story/to-make-a-project-successful-without-wasting-time-on-unwanted-manual-efforts-2/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Brijnandan Singh Chauhan
   location: India
   industries:
     - Telecomunications

--- a/src/user-story/to-make-better-recommendations/index.yaml
+++ b/src/user-story/to-make-better-recommendations/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Tidhar Klein Orbach
   location: Israel
   industries:
     - Advertising & Marketing

--- a/src/user-story/to-make-ci-easier/index.yaml
+++ b/src/user-story/to-make-ci-easier/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Guillermo Zarzuelo
   location: Spain
   industries:
     - Digital Products

--- a/src/user-story/to-make-ci-testing-management-easy-and-enjoyable/index.yaml
+++ b/src/user-story/to-make-ci-testing-management-easy-and-enjoyable/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Konstantin Starovoytov
   location: Belarus
   industries:
     - E-commerce & Retail

--- a/src/user-story/to-make-life-easy-and-fast/index.yaml
+++ b/src/user-story/to-make-life-easy-and-fast/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Mitchell Slotboom
   location: Netherlands
   industries:
     - Semiconductors

--- a/src/user-story/to-make-my-life-in-the-test-core-team-great-again/index.yaml
+++ b/src/user-story/to-make-my-life-in-the-test-core-team-great-again/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Martin Pokorny
   location: Austria
   industries:
     - Software Development

--- a/src/user-story/to-make-our-life-easier/index.yaml
+++ b/src/user-story/to-make-our-life-easier/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Oleh Moskovych
   location: Ukraine
   industries:
     - Information Technology

--- a/src/user-story/to-make-the-devops-process-simple-and-enjoyable/index.yaml
+++ b/src/user-story/to-make-the-devops-process-simple-and-enjoyable/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Akshit Singhal
   location: India
   industries:
     - Automotive

--- a/src/user-story/to-make-your-configuration-as-a-code-possible/index.yaml
+++ b/src/user-story/to-make-your-configuration-as-a-code-possible/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Amet Umerov
   location: Ukraine
   industries:
     - Education

--- a/src/user-story/to-make-your-work-comfortable/index.yaml
+++ b/src/user-story/to-make-your-work-comfortable/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Kanstantsin Harbachou
   location: Belarus
   industries:
     - Legal

--- a/src/user-story/to-manage-anything-and-everything-through-pipelines/index.yaml
+++ b/src/user-story/to-manage-anything-and-everything-through-pipelines/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Nitish Chandu Oggu
   location: India
   industries:
     - Financial Services

--- a/src/user-story/to-manage-minecraft-in-the-cloud/index.yaml
+++ b/src/user-story/to-manage-minecraft-in-the-cloud/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Richard Staehler III
   location: Illinois, USA
   industries:
     - Gaming

--- a/src/user-story/to-manageable-ui-test-automation/index.yaml
+++ b/src/user-story/to-manageable-ui-test-automation/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Julio Valls
   location: Spain
   industries:
     - Consulting

--- a/src/user-story/to-migrate-telecom-applications-to-the-cloud/index.yaml
+++ b/src/user-story/to-migrate-telecom-applications-to-the-cloud/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Saikat Das
   location: India
   industries:
     - Telecomunications

--- a/src/user-story/to-modernize-healthcare/index.yaml
+++ b/src/user-story/to-modernize-healthcare/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Vitor Lobao
   location: Brazil
   industries:
     - Healthcare

--- a/src/user-story/to-modernize-your-devops-platform/index.yaml
+++ b/src/user-story/to-modernize-your-devops-platform/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Rahul Kumar
   location: India
   industries:
     - Financial Services / Payments

--- a/src/user-story/to-own-the-future/index.yaml
+++ b/src/user-story/to-own-the-future/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Ethan Collopy
   location: United Kingdom
   industries:
     - Financial Services

--- a/src/user-story/to-own-the-software-lifecycle/index.yaml
+++ b/src/user-story/to-own-the-software-lifecycle/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Vijay Sundar V
   location: India
   industries:
     - Network Communications

--- a/src/user-story/to-produce-ultra-modern-and-sophisticated-electronic-devices/index.yaml
+++ b/src/user-story/to-produce-ultra-modern-and-sophisticated-electronic-devices/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Ankit Menon
   location: India
   industries:
     - Consumer Electronics

--- a/src/user-story/to-rapid-development-and-testing/index.yaml
+++ b/src/user-story/to-rapid-development-and-testing/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Gaurav Talreja
   location: India
   industries:
     - Testing

--- a/src/user-story/to-rapid-prototyping-life-science-applications/index.yaml
+++ b/src/user-story/to-rapid-prototyping-life-science-applications/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Ioannis Moutsatsos
   location: Massachusetts, USA
   industries:
     - Medical Research

--- a/src/user-story/to-revolutionize-the-integration-of-new-technologies/index.yaml
+++ b/src/user-story/to-revolutionize-the-integration-of-new-technologies/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Cyril Tavian
   location: France
   industries:
     - Automotive

--- a/src/user-story/to-revolutionize-the-world-of-automation/index.yaml
+++ b/src/user-story/to-revolutionize-the-world-of-automation/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Daksh Jain
   location: India
   industries:
     - Information Technology

--- a/src/user-story/to-robot-em-all/index.yaml
+++ b/src/user-story/to-robot-em-all/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Victor Martinez
   location: Spain
   industries:
     - Software Development

--- a/src/user-story/to-run-technical-simulations-for-developer-engineer-interviews/index.yaml
+++ b/src/user-story/to-run-technical-simulations-for-developer-engineer-interviews/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Carlos Rodriguez Lopez
   location: Spain
   industries:
     - DevOps & Human Resources

--- a/src/user-story/to-save-money/index.yaml
+++ b/src/user-story/to-save-money/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Leandro Martins
   location: Germany
   industries:
     - E-commerce & Retail

--- a/src/user-story/to-save-the-day/index.yaml
+++ b/src/user-story/to-save-the-day/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Eric Courville
   location: California, USA
   industries:
     - Information Technology

--- a/src/user-story/to-save-your-valuable-time/index.yaml
+++ b/src/user-story/to-save-your-valuable-time/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Abhineet Saxena
   location: India
   industries:
     - Information Technology

--- a/src/user-story/to-scale-from-the-ground-up/index.yaml
+++ b/src/user-story/to-scale-from-the-ground-up/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Nicolas Magnone
   location: Spain
   industries:
     - Financial Services

--- a/src/user-story/to-scale-your-builds/index.yaml
+++ b/src/user-story/to-scale-your-builds/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Thibaut Le Levier
   location: France
   industries:
     - Software Development

--- a/src/user-story/to-scale-your-ci-cd-pipelines/index.yaml
+++ b/src/user-story/to-scale-your-ci-cd-pipelines/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Sérgio Martins
   location: Portugal
   industries:
     - Fashion

--- a/src/user-story/to-simplify-the-cloud-onboarding-process/index.yaml
+++ b/src/user-story/to-simplify-the-cloud-onboarding-process/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Ant Kenworthy
   location: United Kingdom
   industries:
     - Government

--- a/src/user-story/to-simplify-things-for-devops-world/index.yaml
+++ b/src/user-story/to-simplify-things-for-devops-world/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Prudviraj Pentakota
   location: India
   industries:
     - Software Developement

--- a/src/user-story/to-space/index.yaml
+++ b/src/user-story/to-space/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Marcin Drobik
   location: Poland
   industries:
     - Aerospace

--- a/src/user-story/to-speed-up-the-product-development-process/index.yaml
+++ b/src/user-story/to-speed-up-the-product-development-process/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Erana Chandran
   location: India
   industries:
     - Information Technology

--- a/src/user-story/to-speed-up-the-world/index.yaml
+++ b/src/user-story/to-speed-up-the-world/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Pablo Del Giudice
   location: Argentina
   industries:
     - Financial Services

--- a/src/user-story/to-successfully-deploy-enterprise-level-applications/index.yaml
+++ b/src/user-story/to-successfully-deploy-enterprise-level-applications/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Debobrata Bose
   location: India
   industries:
     - Financial Services

--- a/src/user-story/to-tackle-any-challenge/index.yaml
+++ b/src/user-story/to-tackle-any-challenge/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Mark Baumann
   location: Germany
   industries:
     - Software Development

--- a/src/user-story/to-take-the-pressure-off-your-dev-teams/index.yaml
+++ b/src/user-story/to-take-the-pressure-off-your-dev-teams/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Peter Carenza, DevOps Specialist
   location: Chattanooga, Tennessee, USA
   industries:
     - Healthcare

--- a/src/user-story/to-test-software-packages-overnight/index.yaml
+++ b/src/user-story/to-test-software-packages-overnight/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Mallanna Biradar
   location: India
   industries:
     - Semiconductors

--- a/src/user-story/to-transform-server-build-automation/index.yaml
+++ b/src/user-story/to-transform-server-build-automation/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Jon Wright
   location: Colorado, USA
   industries:
     - Information Technology

--- a/src/user-story/to-transformation/index.yaml
+++ b/src/user-story/to-transformation/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Shyam Thadichetti
   location: India
   industries:
     - Healthcare

--- a/src/user-story/to-truly-automate-everything/index.yaml
+++ b/src/user-story/to-truly-automate-everything/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: V Roshan Kumar Patro
   location: India
   industries:
     - Information Technology

--- a/src/user-story/to-understand-and-simplify-your-software-workflows-2/index.yaml
+++ b/src/user-story/to-understand-and-simplify-your-software-workflows-2/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Javier Méndez Veira
   location: Spain
   industries:
     - Education

--- a/src/user-story/to-understand-and-simplify-your-software-workflows/index.yaml
+++ b/src/user-story/to-understand-and-simplify-your-software-workflows/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Koen Poppe
   location: Belgium
   industries:
     - DevOps & Machine Learning

--- a/src/user-story/to-write-awesome-code/index.yaml
+++ b/src/user-story/to-write-awesome-code/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Johannes Mayer
   location: Germany
   industries:
     - Binary Translation


### PR DESCRIPTION
## Description:

-This pull request reintroduces the authored_by field in the map popups that was removed during the merge of PR #80. The field displays the author's name in the map popups, enhancing the user experience by providing additional context about the user stories.

## Changes Made:

1.Updated map.jsx:

-Added the authored_by field back.
-Modified the popup component to display the authored_by field along with other details.

2.Updated YAML Files:

-Ensured that the authored_by field is present in all relevant YAML files to ensure the data is available for the map popups.

## Impact:

-The map now correctly displays the author's name in the popup for each user story, alongside other information such as industries and the link to read the full user story.


### Before merging of PR #80:

<img width="1512" alt="Screenshot 2025-01-28 at 10 15 58 AM" src="https://github.com/user-attachments/assets/0ce51f90-307b-4933-b92a-fbb8c1101eaa" />

### After merging of PR #80:

<img width="1512" alt="Screenshot 2025-01-28 at 10 12 57 AM" src="https://github.com/user-attachments/assets/fd3123eb-6d20-4fd1-8b04-5cac316d15ba" />

### After this PR :

<img width="1512" alt="Screenshot 2025-01-28 at 10 17 31 AM" src="https://github.com/user-attachments/assets/ef722b80-ea64-4156-82de-13e268eaecde" />



## Testing:

-Verified that the authored_by field is correctly populated in the map popups.
-Ensured that the changes do not affect other functionalities of the map or the user story pages.


Please review the changes and let me know if any further modifications are needed.