### PR TITLE
Restore Correct Authorship(Fixes PR #80 and PR #91 Issues)

### DIFF
--- a/src/pages/map.jsx
+++ b/src/pages/map.jsx
@@ -28,6 +28,7 @@ const MapPage = () => {
         edges {
           node {
             map {
+              authored_by
               latitude
               longitude
               industries
@@ -132,6 +133,7 @@ const MapPage = () => {
                                 padding: '5px',
                               }}
                             >
+                              <dt>{story.map.authored_by}</dt>
                               <dt>{story.map.location}</dt>
                               <dt>
                                 {(

--- a/src/user-story/a-stable-projects-life/index.yaml
+++ b/src/user-story/a-stable-projects-life/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Konstantin Averkiev
   location: Belarus
   industries:
     - Information Technology

--- a/src/user-story/customers-digital-transformation/index.yaml
+++ b/src/user-story/customers-digital-transformation/index.yaml
@@ -2,7 +2,7 @@
 title: Facilitating Customers' Digital Transformation Based on Jenkins
 post_name: customers-digital-transformation
 date: 2024-11-25
-authored_by: Alauda
+authored_by: Zhipeng Yu
 tag_line: "Alauda: The AI-Ready Cloud Native Solution"
 image: alauda.png
 metadata:
@@ -26,6 +26,7 @@ metadata:
     - Yes
 quotes: []
 map:
+  authored_by: Zhipeng Yu 
   location: Beijing, China
   latitude: "39.9042"
   longitude: "116.4074"

--- a/src/user-story/jenkins-is-the-way-for-networkupstools/index.yaml
+++ b/src/user-story/jenkins-is-the-way-for-networkupstools/index.yaml
@@ -2,7 +2,7 @@
 title: Jenkins is the way to build multi-platform NUT
 post_name: jenkins-is-the-way-for-networkupstools
 date: 2022-10-02T19:59:30.309+02:00
-authored_by: Konstantin Averkiev
+authored_by: Jim Klimov
 tag_line: Jenkins is the way to build multi-platform NUT, and jenkinsfile-dynamatrix is the way to find what can be built today
 image: jenkins-nut-large-squared.png
 metadata:
@@ -30,6 +30,7 @@ metadata:
     - Yes
 quotes: []
 map:
+  authored_by: Jim Klimov
   location: Prague, CZ
   latitude: "50.0755"
   longitude: "14.4378"

--- a/src/user-story/jenkins-is-the-way-to-automate-all-the-things/index.yaml
+++ b/src/user-story/jenkins-is-the-way-to-automate-all-the-things/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Christopher Duffy
   location: Florida, USA
   industries:
     - Technology

--- a/src/user-story/jenkins-is-the-way-to-automate-ci-cd-efficiently/index.yaml
+++ b/src/user-story/jenkins-is-the-way-to-automate-ci-cd-efficiently/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Bibek Sutradhar
   location: India
   industries:
     - Consulting

--- a/src/user-story/jenkins-is-the-way-to-build-robust-and-specific-pipelines/index.yaml
+++ b/src/user-story/jenkins-is-the-way-to-build-robust-and-specific-pipelines/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Alexis Couvreur
   location: France
   industries:
     - Information Technology
@@ -91,7 +92,7 @@ body_content:
       *   automated semantic versioning based on commit messages
 title: Jenkins is the way to build robust and specific pipelines
 date: 2021-02-28T13:41:20.000Z
-authored_by: Alexandre Hiltcher
+authored_by: Alexis Couvreur
 post_name: jenkins-is-the-way-to-build-robust-and-specific-pipelines
 quotes:
   - from: Alexis Couvreur, Software Engineer and DevOps Evangelist

--- a/src/user-story/jenkins-is-the-way-to-create-an-awesome-pipeline/index.yaml
+++ b/src/user-story/jenkins-is-the-way-to-create-an-awesome-pipeline/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Amandep Singh
   location: India
   industries:
     - Telecomunications

--- a/src/user-story/jenkins-is-the-way-to-deliver-telecom-platforms-around-the-globe/index.yaml
+++ b/src/user-story/jenkins-is-the-way-to-deliver-telecom-platforms-around-the-globe/index.yaml
@@ -70,7 +70,7 @@ body_content:
 title: Jenkins is the way to deliver telecom platforms around the globe
 date: 2021-04-23T14:17:16.000Z
 authored_by: Joana Carneiro
-post_name: a-stable-projects-life-cycle-with-jenkins
+post_name: jenkins-is-the-way-to-deliver-telecom-platforms-around-the-globe
 quotes:
   - from: Joana Carneiro, Software Developer
     content: '"Life is so much easier for the developers that they can really focus

--- a/src/user-story/jenkins-is-the-way-to-deliver-telecom-platforms-around-the-globe/index.yaml
+++ b/src/user-story/jenkins-is-the-way-to-deliver-telecom-platforms-around-the-globe/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Joana Carneiro
   location: Portugal
   industries:
     - Telecomunications

--- a/src/user-story/jenkins-is-the-way-to-developer-paradise/index.yaml
+++ b/src/user-story/jenkins-is-the-way-to-developer-paradise/index.yaml
@@ -73,7 +73,7 @@ body_content:
       *   Better deployment practices improved overall efficiency and code quality (now with Sonarqube!)
 title: Jenkins is the way to developer paradise
 date: 2021-10-10T17:52:58.000Z
-authored_by: John Crafton, Sr. Software Architect
+authored_by: John Crafton
 post_name: jenkins-is-the-way-to-developer-paradise
 quotes:
   - from: John Crafton, Sr. Software Architect

--- a/src/user-story/jenkins-is-the-way-to-devops-in-any-technology/index.yaml
+++ b/src/user-story/jenkins-is-the-way-to-devops-in-any-technology/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Jorge Hidalgo
   location: Spain
   industries:
     - Cloud Computing

--- a/src/user-story/jenkins-is-the-way-to-enable-teams-to-ship-software-swiftly/index.yaml
+++ b/src/user-story/jenkins-is-the-way-to-enable-teams-to-ship-software-swiftly/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Gaurav Nanda
   location: India
   industries:
     - Software Developement

--- a/src/user-story/jenkins-is-the-way-to-fintech-excellence/index.yaml
+++ b/src/user-story/jenkins-is-the-way-to-fintech-excellence/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Lara Evdokimova
   location: Russia
   industries:
     - Financial Services

--- a/src/user-story/jenkins-is-the-way-to-improve-solution-development/index.yaml
+++ b/src/user-story/jenkins-is-the-way-to-improve-solution-development/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Anthony Alberto Alcala Beltran
   location: Peru
   industries:
     - Information Technology

--- a/src/user-story/jenkins-is-the-way-to-revolutionize-loyalty-programs/index.yaml
+++ b/src/user-story/jenkins-is-the-way-to-revolutionize-loyalty-programs/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Gabriel Rosales
   location: Florida, USA
   industries:
     - Financial Services

--- a/src/user-story/jenkins-is-the-way-to-show-people-how-its-done/index.yaml
+++ b/src/user-story/jenkins-is-the-way-to-show-people-how-its-done/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Filipe Costa
   location: Portugal
   industries:
     - Information Technology

--- a/src/user-story/jenkins-is-the-way-to-transform-healthcare/index.yaml
+++ b/src/user-story/jenkins-is-the-way-to-transform-healthcare/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Ashutosh Pattanaik
   location: India
   industries:
     - Healthcare

--- a/src/user-story/jenkins-is-the-way-to-win/index.yaml
+++ b/src/user-story/jenkins-is-the-way-to-win/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Thomas Haver
   location: Ohio, USA
   industries:
     - Financial Services

--- a/src/user-story/to-a-streamlined-mortgage-industry/index.yaml
+++ b/src/user-story/to-a-streamlined-mortgage-industry/index.yaml
@@ -1,6 +1,6 @@
 ---
 map:
-  authored_by: Arman Chand, Software Engineer
+  authored_by: Arman Chand
   location: India
   industries:
     - Financial Services - Mortgage
@@ -65,7 +65,7 @@ body_content:
       *   Automated CMS code and configuration backups to source control
 title: Jenkins is the way to a streamlined mortgage industry
 date: 2021-05-25T00:08:22.000Z
-authored_by: Arman Chand, Software Engineer
+authored_by: Arman Chand
 post_name: to-a-streamlined-mortgage-industry
 quotes:
   - from: Arman Chand, Software Engineer

--- a/src/user-story/to-a-streamlined-mortgage-industry/index.yaml
+++ b/src/user-story/to-a-streamlined-mortgage-industry/index.yaml
@@ -1,6 +1,6 @@
 ---
 map:
-  authored_by: Arman Chand
+  authored_by: Arman Chand, Software Engineer
   location: India
   industries:
     - Financial Services - Mortgage

--- a/src/user-story/to-a-streamlined-mortgage-industry/index.yaml
+++ b/src/user-story/to-a-streamlined-mortgage-industry/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Arman Chand
   location: India
   industries:
     - Financial Services - Mortgage

--- a/src/user-story/to-accelerate-automation-in-the-cloud/index.yaml
+++ b/src/user-story/to-accelerate-automation-in-the-cloud/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Gaurav Agarwal
   location: United Kingdom
   industries:
     - Logistics

--- a/src/user-story/to-accelerate-production/index.yaml
+++ b/src/user-story/to-accelerate-production/index.yaml
@@ -61,7 +61,7 @@ body_content:
       *   Ability to monitor jobs and other things in Jenkins
 title: Jenkins is the way to accelerate production
 date: 2021-08-25T13:30:39.000Z
-authored_by: Ankur Dhakar, Student, University of Allahabad
+authored_by: Ankur Dhakar
 post_name: to-accelerate-production
 quotes:
   - from: Ankur Dhakar, Student, University of Allahabad

--- a/src/user-story/to-access-the-best-open-source-tool/index.yaml
+++ b/src/user-story/to-access-the-best-open-source-tool/index.yaml
@@ -47,7 +47,7 @@ body_content:
       *   a fully-functional continuous integration platform
 title: Jenkins is the way to access the best open source tool
 date: 2021-12-20T17:42:08.000Z
-authored_by: Antoine Pritzy, Jenkins Administrator, Vetoquinol
+authored_by: Antoine Pritzy
 post_name: to-access-the-best-open-source-tool
 quotes:
   - from: Antoine Pritzy, Jenkins Administrator, Vetoquinol

--- a/src/user-story/to-achieve-a-stable-cicd-enterprise-solution/index.yaml
+++ b/src/user-story/to-achieve-a-stable-cicd-enterprise-solution/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Emil Vulkov
   location: Bulgaria
   industries:
     - Financial Services

--- a/src/user-story/to-achieve-accuracy/index.yaml
+++ b/src/user-story/to-achieve-accuracy/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Abhinav Dubey
   location: India
   industries:
     - DevOps & Machine Learning

--- a/src/user-story/to-achieve-greater-flexibility-in-projects-faster-deployments/index.yaml
+++ b/src/user-story/to-achieve-greater-flexibility-in-projects-faster-deployments/index.yaml
@@ -79,7 +79,7 @@ body_content:
 title: Jenkins is the way to achieve greater flexibility in projects & faster
   deployments
 date: 2021-10-15T18:09:23.000Z
-authored_by: Aman Makwana, DevOps
+authored_by: Aman Makwana
 post_name: to-achieve-greater-flexibility-in-projects-faster-deployments
 quotes:
   - from: Aman Makwana, DevOps

--- a/src/user-story/to-achieve-simple-effective-code-driven-ci-cd-and-other-automation-pipelines/index.yaml
+++ b/src/user-story/to-achieve-simple-effective-code-driven-ci-cd-and-other-automation-pipelines/index.yaml
@@ -88,7 +88,7 @@ body_content:
 title: Jenkins is the way to achieve simple, effective, code-driven CI/CD and
   other automation pipelines
 date: 2021-09-11T14:19:05.000Z
-authored_by: Timothy Go
+authored_by: Joshua Zangari
 post_name: jenkins-is-the-way-to-achieve-simple-effective-code-driven-ci-cd-and-other-automation-pipelines
 quotes:
   - from: Joshua Zangari, Devops Lead, Moogsoft

--- a/src/user-story/to-achieve-simple-effective-code-driven-ci-cd-and-other-automation-pipelines/index.yaml
+++ b/src/user-story/to-achieve-simple-effective-code-driven-ci-cd-and-other-automation-pipelines/index.yaml
@@ -89,7 +89,7 @@ title: Jenkins is the way to achieve simple, effective, code-driven CI/CD and
   other automation pipelines
 date: 2021-09-11T14:19:05.000Z
 authored_by: Joshua Zangari
-post_name: jenkins-is-the-way-to-achieve-simple-effective-code-driven-ci-cd-and-other-automation-pipelines
+post_name: to-achieve-simple-effective-code-driven-ci-cd-and-other-automation-pipelines
 quotes:
   - from: Joshua Zangari, Devops Lead, Moogsoft
     content: Honestly, Jenkins made it simple to do what other tools like Spinnaker

--- a/src/user-story/to-achieve-speed-correctness/index.yaml
+++ b/src/user-story/to-achieve-speed-correctness/index.yaml
@@ -67,7 +67,7 @@ body_content:
       *   Builds are categorized by the errors & debugged easily
 title: Jenkins is the way to achieve speed & correctness
 date: 2021-09-03T15:46:28.000Z
-authored_by: Shreyas Subhedar, Associate Engineer DevOps, Acquia Inc.
+authored_by: Shreyas Subhedar
 post_name: to-achieve-speed-correctness
 quotes:
   - from: Shreyas Subhedar, Associate Engineer DevOps, Acquia Inc.

--- a/src/user-story/to-add-spicy-flavors-to-muzkats-processes/index.yaml
+++ b/src/user-story/to-add-spicy-flavors-to-muzkats-processes/index.yaml
@@ -70,7 +70,7 @@ body_content:
       *   shared knowledge across a happy team
 title: Jenkins is the way to add spicy flavors to Muzkat's processes
 date: 2020-09-10T15:41:18.000Z
-authored_by: Erik Woitschig, Founder / Developer, Muzkat
+authored_by: Erik Woitschig
 post_name: to-add-spicy-flavors-to-muzkats-processes
 quotes:
   - from: Erik Woitschig, Founder / Developer, Muzkat

--- a/src/user-story/to-add-spicy-flavors-to-muzkats-processes/index.yaml
+++ b/src/user-story/to-add-spicy-flavors-to-muzkats-processes/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Erik Woitschig
   location: Germany
   industries:
     - Advertising & Marketing

--- a/src/user-story/to-add-stability-to-the-overall-software-delivery-process/index.yaml
+++ b/src/user-story/to-add-stability-to-the-overall-software-delivery-process/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Ajit Gunge
   location: India
   industries:
     - Telecomunications

--- a/src/user-story/to-add-stability-to-the-overall-software-delivery-process/index.yaml
+++ b/src/user-story/to-add-stability-to-the-overall-software-delivery-process/index.yaml
@@ -63,7 +63,7 @@ body_content:
       *   End-users report overall quality of the software has increased and is more bug free\*\*
 title: Jenkins is the way to add stability to the overall software delivery process
 date: 2020-08-08T19:29:18.000Z
-authored_by: Ajit Gunge, Lead Consultant, Virtusa
+authored_by: Ajit Gunge
 post_name: to-add-stability-to-the-overall-software-delivery-process
 quotes:
   - from: Ajit Gunge, Lead Consultant, Virtusa

--- a/src/user-story/to-allow-people-to-self-service-help-launch-stuff-stabilize-releases-and-encourage-developers/index.yaml
+++ b/src/user-story/to-allow-people-to-self-service-help-launch-stuff-stabilize-releases-and-encourage-developers/index.yaml
@@ -83,7 +83,7 @@ body_content:
 title: Jenkins is the way to allow people to self-service, help launch stuff,
   stabilize releases, and encourage developers
 date: 2021-09-10T13:57:49.000Z
-authored_by: Stefan Martinov, DevOps Lead
+authored_by: Stefan Martinov
 post_name: to-allow-people-to-self-service-help-launch-stuff-stabilize-releases-and-encourage-developers
 quotes:
   - from: Stefan Martinov DevOps Lead

--- a/src/user-story/to-amazing-automation/index.yaml
+++ b/src/user-story/to-amazing-automation/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Mitchell Locktree
   location: Netherlands
   industries:
     - Semiconductors

--- a/src/user-story/to-automate-almost-anything-in-an-enterprise/index.yaml
+++ b/src/user-story/to-automate-almost-anything-in-an-enterprise/index.yaml
@@ -101,7 +101,7 @@ body_content:
       *   Failback or failover chances are slim
 title: Jenkins is the way to automate almost anything in an enterprise
 date: 2021-03-05T17:05:03.000Z
-authored_by: Jatin Bedi, CI/CD Consultant
+authored_by: Jatin Bedi
 post_name: to-automate-almost-anything-in-an-enterprise
 quotes:
   - from: Jatin Bedi, CI/CD Consultant

--- a/src/user-story/to-automate-almost-anything-in-an-enterprise/index.yaml
+++ b/src/user-story/to-automate-almost-anything-in-an-enterprise/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Jatin Bedi
   location: California, USA
   industries:
     - Information Technology

--- a/src/user-story/to-automate-and-accelerate-application-deployment/index.yaml
+++ b/src/user-story/to-automate-and-accelerate-application-deployment/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Mary Jane Buenaventura
   location: Malaysia
   industries:
     - Information Technology
@@ -65,6 +66,7 @@ body_content:
       *   concurrent builds help a lot on our productivity
 title: Jenkins is the way to automate and accelerate application deployment
 date: 2021-05-31T14:19:58.000Z
+authored_by: Mary Jane Buenaventura
 post_name: to-automate-and-accelerate-application-deployment
 quotes:
   - from: Mary Jane Buenaventura, Solution Architect

--- a/src/user-story/to-automate-and-improve/index.yaml
+++ b/src/user-story/to-automate-and-improve/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Andreas Schwarzkopf
   location: Germany
   industries:
     - Automotive

--- a/src/user-story/to-automate-anything-in-healthcare/index.yaml
+++ b/src/user-story/to-automate-anything-in-healthcare/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Vishal VR Gowda
   location: India
   industries:
     - Healthcare

--- a/src/user-story/to-automate-builds-and-tests/index.yaml
+++ b/src/user-story/to-automate-builds-and-tests/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Jayant Sikarwar
   location: India
   industries:
     - Financial Services

--- a/src/user-story/to-automate-complex-tasks/index.yaml
+++ b/src/user-story/to-automate-complex-tasks/index.yaml
@@ -63,7 +63,7 @@ body_content:
       *   seamless implementation of pipelines
 title: Jenkins is the way to automate complex tasks
 date: 2021-10-23T16:04:43.000Z
-authored_by: Joana Carneiro
+authored_by: Fabio Segredo
 post_name: to-automate-complex-tasks
 quotes:
   - from: Fabio Segredo, DevOps Team

--- a/src/user-story/to-automate-continuous-delivery-pipelines/index.yaml
+++ b/src/user-story/to-automate-continuous-delivery-pipelines/index.yaml
@@ -74,7 +74,7 @@ body_content:
       *   containerization
 title: Jenkins is the way to automate continuous delivery pipelines
 date: 2020-10-27T14:22:58.000Z
-author: Jon Brohauge, DevTools Engineer, Topdanmark A/S
+authored_by: Jon Brohauge
 post_name: to-automate-continuous-delivery-pipelines
 quotes:
   - from: Jon Brohauge, DevTools Engineer, Topdanmark A/S

--- a/src/user-story/to-automate-continuous-delivery-pipelines/index.yaml
+++ b/src/user-story/to-automate-continuous-delivery-pipelines/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Jon Brohauge
   location: Denmark
   industries:
     - Insurance

--- a/src/user-story/to-automate-development-tasks/index.yaml
+++ b/src/user-story/to-automate-development-tasks/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Bilal Bailey
   location: Illinois, USA
   industries:
     - Manufacturing

--- a/src/user-story/to-automate-everything/index.yaml
+++ b/src/user-story/to-automate-everything/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Yazeed AL-Smadi
   location: Jordan
   industries:
     - Healthcare

--- a/src/user-story/to-automate-noc-operations/index.yaml
+++ b/src/user-story/to-automate-noc-operations/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Alexander Leibzon
   location: Israel
   industries:
     - Advertising & Marketing

--- a/src/user-story/to-automate-noc-operations/index.yaml
+++ b/src/user-story/to-automate-noc-operations/index.yaml
@@ -79,7 +79,7 @@ body_content:
       *   Being pipeline compatible
 title: Jenkins is the way to automate NOC operations
 date: 2020-05-14T02:02:39.000Z
-authored_by: Alexander Leibzon, Software Developer/Architect
+authored_by: Alexander Leibzon
 post_name: to-automate-noc-operations
 quotes:
   - from: Alexander Leibzon, Software Developer/Architect

--- a/src/user-story/to-automate-test-execution-and-manage-distributed-systems/index.yaml
+++ b/src/user-story/to-automate-test-execution-and-manage-distributed-systems/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Gábor Barna
   location: Hungary
   industries:
     - Telecomunications

--- a/src/user-story/to-automate-testing-reporting-and-scaling/index.yaml
+++ b/src/user-story/to-automate-testing-reporting-and-scaling/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Anand Bhagwat
   location: India
   industries:
     - Artificial Intelligence (AI)

--- a/src/user-story/to-automate-the-boring-stuff/index.yaml
+++ b/src/user-story/to-automate-the-boring-stuff/index.yaml
@@ -66,7 +66,7 @@ body_content:
       *   Releases cycles shortened from 3 days to 3 hours
 title: Jenkins is the way to automate the boring stuff
 date: 2021-02-22T16:06:45.000Z
-authored_by: Mohamad Farhan bin Zainudin, Cloud Engineer
+authored_by: Mohamad Farhan bin Zainudin
 post_name: to-automate-the-boring-stuff
 quotes:
   - from: Mohamad Farhan bin Zainudin, Cloud Engineer

--- a/src/user-story/to-automate-the-boring-stuff/index.yaml
+++ b/src/user-story/to-automate-the-boring-stuff/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Mohamad Farhan bin Zainudin
   location: Malaysia
   industries:
     - DevOps as a Service

--- a/src/user-story/to-automate-the-future-for-developers/index.yaml
+++ b/src/user-story/to-automate-the-future-for-developers/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Manasi Jha
   location: India
   industries:
     - Engineering

--- a/src/user-story/to-automate-the-lives-of-all-programmers-who-want-a-quality-product/index.yaml
+++ b/src/user-story/to-automate-the-lives-of-all-programmers-who-want-a-quality-product/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Diogo Alves de Almeida
   location: Brazil
   industries:
     - Logistics

--- a/src/user-story/to-automate-the-work/index.yaml
+++ b/src/user-story/to-automate-the-work/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Vilsi Jain
   location: India
   industries:
     - Technology
@@ -66,7 +67,7 @@ body_content:
       *   worked earlier
 title: Jenkins is the way to automate the work
 date: 2021-08-15T13:32:33.000Z
-authored_by: Vilsi Jain, Student, Jaipur Engineering College and Research Centre
+authored_by: Vilsi Jain
 post_name: to-automate-the-work
 quotes:
   - from: Vilsi Jain, Student, Jaipur Engineering College and Research Centre

--- a/src/user-story/to-automate-the-world/index.yaml
+++ b/src/user-story/to-automate-the-world/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Sebastien Sirtoli
   location: Belgium
   industries:
     - Transport

--- a/src/user-story/to-automate-your-job-and-transform-your-life/index.yaml
+++ b/src/user-story/to-automate-your-job-and-transform-your-life/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Damian Zermeño
   location: Mexico
   industries:
     - Electronics Manufacturing

--- a/src/user-story/to-awesome-delivery-with-accurate-ci-cd-setup/index.yaml
+++ b/src/user-story/to-awesome-delivery-with-accurate-ci-cd-setup/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Ashish Kumar Das
   location: India
   industries:
     - Telecomunications

--- a/src/user-story/to-bridge-gaps/index.yaml
+++ b/src/user-story/to-bridge-gaps/index.yaml
@@ -36,7 +36,7 @@ body_content:
       *   Result #3 -- No manual run
 title: Jenkins is the way to bridge gaps
 date: 2021-11-01T16:24:52.000Z
-authored_by: Mayank Goyal, Developer in India
+authored_by: Mayank Goyal
 post_name: to-bridge-gaps
 quotes:
   - from: Mayank Goyal, Developer in India

--- a/src/user-story/to-bring-brazils-freight-workers-to-the-21st-century/index.yaml
+++ b/src/user-story/to-bring-brazils-freight-workers-to-the-21st-century/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Luís Felipe Teixeira
   location: Brazil
   industries:
     - Logistics
@@ -67,7 +68,7 @@ body_content:
       *   build parallelization and version management of the images created
 title: Jenkins is the way to bring Brazil's freight workers to the 21st century
 date: 2021-04-29T15:12:26.000Z
-author: Diogo Almeida
+author: Luís Felipe Teixeira
 post_name: to-bring-brazils-freight-workers-to-the-21st-century
 quotes:
   - from: Luís Felipe Teixeira, Senior Automation Engineer, Sincrovia

--- a/src/user-story/to-bring-brazils-freight-workers-to-the-21st-century/index.yaml
+++ b/src/user-story/to-bring-brazils-freight-workers-to-the-21st-century/index.yaml
@@ -68,7 +68,7 @@ body_content:
       *   build parallelization and version management of the images created
 title: Jenkins is the way to bring Brazil's freight workers to the 21st century
 date: 2021-04-29T15:12:26.000Z
-author: Luís Felipe Teixeira
+authored_by: Luís Felipe Teixeira
 post_name: to-bring-brazils-freight-workers-to-the-21st-century
 quotes:
   - from: Luís Felipe Teixeira, Senior Automation Engineer, Sincrovia

--- a/src/user-story/to-bring-our-community-together/index.yaml
+++ b/src/user-story/to-bring-our-community-together/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Aidan Moriarty
   location: France
   industries:
     - Digital Technology Provider

--- a/src/user-story/to-build-a-scalable-ci-cd-orchestration-platform/index.yaml
+++ b/src/user-story/to-build-a-scalable-ci-cd-orchestration-platform/index.yaml
@@ -1,6 +1,6 @@
 ---
 map:
-  authored_by: Jeff Guzman
+  authored_by: Eric Chapman
   location: Virginia, USA
   industries:
     - Financial Services

--- a/src/user-story/to-build-a-scalable-ci-cd-orchestration-platform/index.yaml
+++ b/src/user-story/to-build-a-scalable-ci-cd-orchestration-platform/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Jeff Guzman
   location: Virginia, USA
   industries:
     - Financial Services

--- a/src/user-story/to-build-and-deliver-software/index.yaml
+++ b/src/user-story/to-build-and-deliver-software/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Amit Dar
   location: Israel
   industries:
     - Defense Technology
@@ -66,7 +67,7 @@ body_content:
       *   project confidence
 title: Jenkins is the way to build and deliver software
 date: 2020-06-09T14:09:24.000Z
-authored_by: Joana Carneiro
+authored_by: Amit Dar
 post_name: to-build-and-deliver-software
 quotes:
   - from: Amit Dar, DevOps Team Leader

--- a/src/user-story/to-build-and-maintain-even-the-most-complex-software-in-the-world/index.yaml
+++ b/src/user-story/to-build-and-maintain-even-the-most-complex-software-in-the-world/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Theodore Chaikalis
   location: Greece
   industries:
     - Government

--- a/src/user-story/to-build-and-release-faster/index.yaml
+++ b/src/user-story/to-build-and-release-faster/index.yaml
@@ -58,7 +58,7 @@ body_content:
       *   ability to focus on important things because we were able to automate the boring stuff by almost 99%
 title: Jenkins is the way to build and release faster
 date: 2021-01-11T18:27:21.000Z
-authored_by: Buvanesh Kumar, Software Engineer, Red Hat
+authored_by: Buvanesh Kumar
 post_name: to-build-and-release-faster
 quotes:
   - from: Buvanesh Kumar, Software Engineer, Red Hat

--- a/src/user-story/to-build-and-release-faster/index.yaml
+++ b/src/user-story/to-build-and-release-faster/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Buvanesh Kumar
   location: India
   industries:
     - Technology

--- a/src/user-story/to-build-and-test-multiple-environments/index.yaml
+++ b/src/user-story/to-build-and-test-multiple-environments/index.yaml
@@ -50,7 +50,7 @@ body_content:
       *   we have the ability to have the status for each step in the pipeline
 title: Jenkins is the way to build and test multiple environments
 date: 2021-06-22T20:28:28.000Z
-authored_by: Emmanouil Katefidis, Cloud Platform Engineer
+authored_by: Emmanouil Katefidis
 post_name: to-build-and-test-multiple-environments
 quotes:
   - from: Emmanouil Katefidis, Cloud Platform Engineer

--- a/src/user-story/to-build-and-test-multiple-environments/index.yaml
+++ b/src/user-story/to-build-and-test-multiple-environments/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Emmanouil Katefidis
   location: Greece
   industries:
     - Cloud Computing

--- a/src/user-story/to-build-chat-bot-driven-declarative-pipelines-for-continuous-delivery/index.yaml
+++ b/src/user-story/to-build-chat-bot-driven-declarative-pipelines-for-continuous-delivery/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Prasanjit Singh
   location: United Arab Emirates
   industries:
     - Media & Entertainment

--- a/src/user-story/to-build-ci-cd-that-fits-advanced-and-unique-use-cases/index.yaml
+++ b/src/user-story/to-build-ci-cd-that-fits-advanced-and-unique-use-cases/index.yaml
@@ -140,7 +140,7 @@ body_content:
       *   A colossal knowledge gain about topics that helps it to perform better, like Kubernetes and infrastructure as code
 title: Jenkins is the way to build CI/CD that fits advanced and unique use cases
 date: 2021-08-19T13:04:06.000Z
-authored_by: Ahmed AbouZaid, DevOps Engineer, Camunda
+authored_by: Ahmed AbouZaid
 post_name: to-build-ci-cd-that-fits-advanced-and-unique-use-cases
 quotes:
   - from: Ahmed AbouZaid, DevOps Engineer, Camunda

--- a/src/user-story/to-build-ci-cd-that-fits-advanced-and-unique-use-cases/index.yaml
+++ b/src/user-story/to-build-ci-cd-that-fits-advanced-and-unique-use-cases/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Ahmed AbouZaid
   location: Germany
   industries:
     - Business Process Modeling (BPM)

--- a/src/user-story/to-build-continuous-communities-in-your-business/index.yaml
+++ b/src/user-story/to-build-continuous-communities-in-your-business/index.yaml
@@ -49,7 +49,7 @@ body_content:
       *   faster release cadence
 title: Jenkins is the way to build continuous communities in your business
 date: 2020-07-23T15:41:43.000Z
-authored_by: James Wasson, Client Solutions Architect
+authored_by: James Wasson
 post_name: to-build-continuous-communities-in-your-business
 quotes:
   - from: James Wasson, Client Solutions Architect

--- a/src/user-story/to-build-continuous-communities-in-your-business/index.yaml
+++ b/src/user-story/to-build-continuous-communities-in-your-business/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: James Wasson
   location: Oklahoma, USA
   industries:
     - Energy

--- a/src/user-story/to-build-faster-and-hassle-free/index.yaml
+++ b/src/user-story/to-build-faster-and-hassle-free/index.yaml
@@ -62,7 +62,7 @@ body_content:
       *   Developer frustration reduced!
 title: Jenkins is the way to build faster and hassle-free
 date: 2021-10-10T15:39:23.000Z
-authored_by: Brendan Elmes, Associate Engineer
+authored_by: Brendan Elmes
 post_name: to-build-faster-and-hassle-free
 quotes:
   - from: Brendan Elmes, Associate Engineer

--- a/src/user-story/to-build-for-the-future/index.yaml
+++ b/src/user-story/to-build-for-the-future/index.yaml
@@ -55,7 +55,7 @@ body_content:
       *   improved application security
 title: Jenkins is the way to build for the future
 date: 2020-08-10T17:16:42.000Z
-authored_by: Gregory Jacobs, Software Architect
+authored_by: Gregory Jacobs
 post_name: to-build-for-the-future
 quotes:
   - from: Gregory Jacobs, Software Architect

--- a/src/user-story/to-build-for-the-future/index.yaml
+++ b/src/user-story/to-build-for-the-future/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Gregory Jacobs
   location: Wisconsin, USA
   industries:
     - Healthcare

--- a/src/user-story/to-build-industry-leading-log-management/index.yaml
+++ b/src/user-story/to-build-industry-leading-log-management/index.yaml
@@ -83,7 +83,7 @@ body_content:
       /).***"
 title: Jenkins is the way to build industry-leading log management
 date: 2020-08-05T17:51:13.000Z
-authored_by: Donald Morton, Build and Release Manager, Graylog
+authored_by: Donald Morton
 post_name: to-build-industry-leading-log-management
 quotes:
   - from: Donald Morton, Build and Release Manager, Graylog

--- a/src/user-story/to-build-industry-leading-log-management/index.yaml
+++ b/src/user-story/to-build-industry-leading-log-management/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Donald Morton
   location: Arkansas, USA
   industries:
     - Software Development

--- a/src/user-story/to-build-projects/index.yaml
+++ b/src/user-story/to-build-projects/index.yaml
@@ -49,7 +49,7 @@ body_content:
       *   Faster development process
 title: Jenkins is the way to build projects
 date: 2021-12-22T17:48:19.000Z
-authored_by: Lyubomir Stanev, Team Lead for T24 Core Development
+authored_by: Lyubomir Stanev
 post_name: to-build-projects
 quotes:
   - from: Lyubomir Stanev, Team Lead for T24 Core Development

--- a/src/user-story/to-cast-magic-of-continuous-delivery-2/index.yaml
+++ b/src/user-story/to-cast-magic-of-continuous-delivery-2/index.yaml
@@ -80,7 +80,7 @@ body_content:
       *   Easier to add new projects and teams
 title: Jenkins is the way to cast magic of continuous delivery
 date: 2020-09-15T16:53:07.000Z
-authored_by: Oleg Tikhonov, DevOps & Infrastructure Architect
+authored_by: Oleg Tikhonov
 post_name: to-cast-magic-of-continuous-delivery-2
 quotes:
   - from: Oleg Tikhonov, DevOps & Infrastructure Architect

--- a/src/user-story/to-cast-magic-of-continuous-delivery-2/index.yaml
+++ b/src/user-story/to-cast-magic-of-continuous-delivery-2/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Oleg Tikhonov
   location: Israel
   industries:
     - Internet of Things (IoT)

--- a/src/user-story/to-cast-magic-of-continuous-delivery/index.yaml
+++ b/src/user-story/to-cast-magic-of-continuous-delivery/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Xuefeng Shi
   location: China
   industries:
     - E-commerce & Retail

--- a/src/user-story/to-completely-automate-your-ci-cd-workflow/index.yaml
+++ b/src/user-story/to-completely-automate-your-ci-cd-workflow/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Oscar Palacios
   location: Florida, USA
   industries:
     - Automotive

--- a/src/user-story/to-consistency/index.yaml
+++ b/src/user-story/to-consistency/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Shauna Wright
   location: Colorado, USA
   industries:
     - Aerospace

--- a/src/user-story/to-continuously-build-test-and-release-your-software/index.yaml
+++ b/src/user-story/to-continuously-build-test-and-release-your-software/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Omprakash Paliwal
   location: India
   industries:
     - Information Technology

--- a/src/user-story/to-continuously-build-test-and-release-your-software/index.yaml
+++ b/src/user-story/to-continuously-build-test-and-release-your-software/index.yaml
@@ -90,7 +90,7 @@ body_content:
       *   10x faster integration of new QualityGates
 title: Jenkins is the way to continuously build, test and release your software
 date: 2021-06-03T14:01:36.000Z
-authored_by: Omprakash Paliwal, Sr. DevOps Engineer
+authored_by: Omprakash Paliwal
 post_name: to-continuously-build-test-and-release-your-software
 quotes:
   - from: Omprakash Paliwal, Sr. DevOps Engineer

--- a/src/user-story/to-cook-almost-everything-in-devops-world/index.yaml
+++ b/src/user-story/to-cook-almost-everything-in-devops-world/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Nilesh Attarde
   location: India
   industries:
     - Product Lifecycle Management (PLM)

--- a/src/user-story/to-create-a-computer-on-wheels/index.yaml
+++ b/src/user-story/to-create-a-computer-on-wheels/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Garima Singh
   location: India
   industries:
     - Education

--- a/src/user-story/to-create-collaboration-between-the-dev-and-the-ops-teams/index.yaml
+++ b/src/user-story/to-create-collaboration-between-the-dev-and-the-ops-teams/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Kuldeep Sharma
   location: India
   industries:
     - Financial Services

--- a/src/user-story/to-create-collaboration-between-the-dev-and-the-ops-teams/index.yaml
+++ b/src/user-story/to-create-collaboration-between-the-dev-and-the-ops-teams/index.yaml
@@ -81,7 +81,7 @@ body_content:
       changes for automation in existing processes.
 title: Jenkins is the way to create collaboration between the Dev and the Ops teams
 date: 2020-10-15T14:06:36.000Z
-authored_by: Kuldeep Sharma, DevOps Lead
+authored_by: Kuldeep Sharma
 post_name: to-create-collaboration-between-the-dev-and-the-ops-teams
 quotes:
   - from: Kuldeep Sharma, DevOps Lead

--- a/src/user-story/to-deliver-amazing-products-easily/index.yaml
+++ b/src/user-story/to-deliver-amazing-products-easily/index.yaml
@@ -98,7 +98,7 @@ body_content:
       *   standardized checks and reporting for products
 title: Jenkins is the way to deliver amazing products easily
 date: 2020-12-17T13:24:20.000Z
-authored_by: Chaitanya Dwivedi, Senior Software Engineer, ARM
+authored_by: Chaitanya Dwivedi
 post_name: to-deliver-amazing-products-easily
 quotes:
   - from: Chaitanya Dwivedi, Senior Software Engineer, ARM

--- a/src/user-story/to-deliver-amazing-products-easily/index.yaml
+++ b/src/user-story/to-deliver-amazing-products-easily/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Chaitanya Dwivedi
   location: Texas, USA
   industries:
     - Semiconductors

--- a/src/user-story/to-deliver-our-new-releases-on-time/index.yaml
+++ b/src/user-story/to-deliver-our-new-releases-on-time/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Jason Shaw
   location: Canada
   industries:
     - Software Development

--- a/src/user-story/to-deliver/index.yaml
+++ b/src/user-story/to-deliver/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Tomas Valentukevicius
   location: Lithuania
   industries:
     - Telecomunications

--- a/src/user-story/to-deploy-a-truly-functional-and-efficient-system-to-manage-build-pipelines/index.yaml
+++ b/src/user-story/to-deploy-a-truly-functional-and-efficient-system-to-manage-build-pipelines/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Joseph Tole
   location: Canada
   industries:
     - Artificial Intelligence (AI)

--- a/src/user-story/to-develop-an-easy-lifestyle-for-developers/index.yaml
+++ b/src/user-story/to-develop-an-easy-lifestyle-for-developers/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Shivanshu Sharma
   location: India
   industries:
     - DevOps Automation

--- a/src/user-story/to-devsecops/index.yaml
+++ b/src/user-story/to-devsecops/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Canux Cheng
   location: China
   industries:
     - Network Security

--- a/src/user-story/to-do-ci-cd-right/index.yaml
+++ b/src/user-story/to-do-ci-cd-right/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Akhil Pradhan
   location: Texas, USA
   industries:
     - Automotive

--- a/src/user-story/to-do-things-quickly-simply-and-in-a-powerful-way/index.yaml
+++ b/src/user-story/to-do-things-quickly-simply-and-in-a-powerful-way/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Alejandro Alvarez Vazquez
   location: Portugal
   industries:
     - Travel
@@ -91,7 +92,7 @@ body_content:
       travel/)"
 title: Jenkins is the way to do things quickly, simply and in a powerful way
 date: 2020-05-26T23:09:24.000Z
-authored_by: Gabriel Ramis, Operation-Infrastructure and Communications Director
+authored_by: Alejandro Alvarez Vazquez
 post_name: to-do-things-quickly-simply-and-in-a-powerful-way
 quotes:
   - from: Alejandro Alvarez Vazquez, Sysadmin, Avoris Travel

--- a/src/user-story/to-drink-coffee-all-day/index.yaml
+++ b/src/user-story/to-drink-coffee-all-day/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Alex Kondrashov
   location: Israel
   industries:
     - Education

--- a/src/user-story/to-drive-software-releases-from-manual-to-autopilot-mode/index.yaml
+++ b/src/user-story/to-drive-software-releases-from-manual-to-autopilot-mode/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Surendra Reddy
   location: India
   industries:
     - Education

--- a/src/user-story/to-easy-development/index.yaml
+++ b/src/user-story/to-easy-development/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Mohammad Hanif
   location: Indonesia
   industries:
     - Engineering

--- a/src/user-story/to-experiments-and-eternity/index.yaml
+++ b/src/user-story/to-experiments-and-eternity/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Eugene Starchenko
   location: Ukraine
   industries:
     - Consulting

--- a/src/user-story/to-explore-different-business-processes/index.yaml
+++ b/src/user-story/to-explore-different-business-processes/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Vlad Silverman
   location: California, USA
   industries:
     - Financial Services

--- a/src/user-story/to-facilitate-day-to-day-work/index.yaml
+++ b/src/user-story/to-facilitate-day-to-day-work/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Anti Asko
   location: France
   industries:
     - Research

--- a/src/user-story/to-facilitate-day-to-day-work/index.yaml
+++ b/src/user-story/to-facilitate-day-to-day-work/index.yaml
@@ -74,7 +74,7 @@ body_content:
       *   faster delivery of hotfixes
 title: Jenkins is the way to facilitate day-to-day work
 date: 2020-04-23T16:09:41.000Z
-authored_by: Anti Asko, Software Engineer, CERN
+authored_by: Anti Asko
 post_name: to-facilitate-day-to-day-work
 quotes:
   - from: Anti Asko, Software Engineer, CERN

--- a/src/user-story/to-faster-and-safer-shipping-to-clients/index.yaml
+++ b/src/user-story/to-faster-and-safer-shipping-to-clients/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Jorge Uztariz
   location: Colombia
   industries:
     - Software Developement

--- a/src/user-story/to-faster-and-safer-shipping-to-clients/index.yaml
+++ b/src/user-story/to-faster-and-safer-shipping-to-clients/index.yaml
@@ -88,7 +88,7 @@ body_content:
       *   no worries about database backups
 title: Jenkins is the way to faster and safer shipping to clients
 date: 2021-08-15T16:10:25.000Z
-authored_by: Jorge Uztariz, Devops Lead, Consis Internacional
+authored_by: Jorge Uztariz
 post_name: to-faster-and-safer-shipping-to-clients
 quotes:
   - from: Jorge Uztariz, Devops Lead, Consis Internacional

--- a/src/user-story/to-faster-product-release/index.yaml
+++ b/src/user-story/to-faster-product-release/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Swaraj Dutta
   location: India
   industries:
     - Information Technology

--- a/src/user-story/to-finally-bring-a-retail-giant-into-the-21st-century/index.yaml
+++ b/src/user-story/to-finally-bring-a-retail-giant-into-the-21st-century/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: John Pope
   location: United Kingdom
   industries:
     - E-commerce & Retail

--- a/src/user-story/to-fulfill-every-build-wish-we-might-come-up-with/index.yaml
+++ b/src/user-story/to-fulfill-every-build-wish-we-might-come-up-with/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Marco de Krijger
   location: Netherlands
   industries:
     - Consulting

--- a/src/user-story/to-get-stuff-done/index.yaml
+++ b/src/user-story/to-get-stuff-done/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Kalin Dimitrov
   location: Sofia, Bulgaria
   industries:
     - Financial Services

--- a/src/user-story/to-give-all-your-work-and-headache-away/index.yaml
+++ b/src/user-story/to-give-all-your-work-and-headache-away/index.yaml
@@ -80,7 +80,7 @@ body_content:
       *   Ultimate ease of life
 title: Jenkins is the way to give all your work and headache away
 date: 2021-10-19T15:54:59.000Z
-authored_by: Anjali Jain, DevOps Intern, Juxta Solution
+authored_by: Anjali Jain
 post_name: to-give-all-your-work-and-headache-away
 quotes:
   - from: Anjali Jain, DevOps Intern, Juxta Solution

--- a/src/user-story/to-give-nitro-to-builds-and-deployments/index.yaml
+++ b/src/user-story/to-give-nitro-to-builds-and-deployments/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Githin Joseph
   location: India
   industries:
     - Travel

--- a/src/user-story/to-guaranteed-quality-for-your-devices/index.yaml
+++ b/src/user-story/to-guaranteed-quality-for-your-devices/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: François Mockers
   location: France
   industries:
     - Internet of Things (IoT)

--- a/src/user-story/to-happy-developers/index.yaml
+++ b/src/user-story/to-happy-developers/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Alan Waite
   location: Pennsylvania, USA
   industries:
     - Robotics

--- a/src/user-story/to-help-developers-properly-do-their-jobs/index.yaml
+++ b/src/user-story/to-help-developers-properly-do-their-jobs/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Christophe Michaux
   location: France
   industries:
     - Financial Services

--- a/src/user-story/to-help-developers-properly-do-their-jobs/index.yaml
+++ b/src/user-story/to-help-developers-properly-do-their-jobs/index.yaml
@@ -91,7 +91,7 @@ body_content:
       *   the process is the same for all of the different projects
 title: Jenkins is the way to help developers properly do their jobs
 date: 2021-03-12T17:28:21.000Z
-authored_by: Christophe Michaux, DevOps CI Engineer
+authored_by: Christophe Michaux
 post_name: to-help-developers-properly-do-their-jobs
 quotes:
   - from: Christophe Michaux, DevOps CI Engineer

--- a/src/user-story/to-help-teams-focus-on-what-is-really-important/index.yaml
+++ b/src/user-story/to-help-teams-focus-on-what-is-really-important/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Eduardo Mandry
   location: Chile
   industries:
     - Financial Services

--- a/src/user-story/to-improve-payment-systems/index.yaml
+++ b/src/user-story/to-improve-payment-systems/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Adam Szatyin
   location: Hungary
   industries:
     - Financial Services

--- a/src/user-story/to-integrate-the-thoughts/index.yaml
+++ b/src/user-story/to-integrate-the-thoughts/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Gyan Gupta
   location: India
   industries:
     - Automotive

--- a/src/user-story/to-keep-ibm-always-on/index.yaml
+++ b/src/user-story/to-keep-ibm-always-on/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Alec Rieger
   location: North Carolina, USA
   industries:
     - Infrastructure

--- a/src/user-story/to-keep-the-world-spinning/index.yaml
+++ b/src/user-story/to-keep-the-world-spinning/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Julio Conchas
   location: Mexico
   industries:
     - Cloud Computing

--- a/src/user-story/to-kill-em-with-agile/index.yaml
+++ b/src/user-story/to-kill-em-with-agile/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Ferdila Rahmi
   location: Indonesia
   industries:
     - Defense Technology

--- a/src/user-story/to-link-deliverability-and-quality/index.yaml
+++ b/src/user-story/to-link-deliverability-and-quality/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Gabriel Poret
   location: France
   industries:
     - Energy
@@ -63,7 +64,7 @@ body_content:
       *   Piloting and metrics facilities
 title: Jenkins is the way to link deliverability and quality
 date: 2021-06-27T19:30:54.000Z
-authored_by: Aurelien Dorey
+authored_by: Gabriel Poret
 post_name: to-link-deliverability-and-quality
 quotes:
   - from: Gabriel Poret, Chief Technology Officer, Consoneo

--- a/src/user-story/to-long-term-automation-strategies/index.yaml
+++ b/src/user-story/to-long-term-automation-strategies/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Bhargav Murarisetty
   location: India
   industries:
     - Software Developement

--- a/src/user-story/to-make-a-project-successful-without-wasting-time-on-unwanted-manual-efforts-2/index.yaml
+++ b/src/user-story/to-make-a-project-successful-without-wasting-time-on-unwanted-manual-efforts-2/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Brijnandan Singh Chauhan
   location: India
   industries:
     - Telecomunications

--- a/src/user-story/to-make-better-recommendations/index.yaml
+++ b/src/user-story/to-make-better-recommendations/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Tidhar Klein Orbach
   location: Israel
   industries:
     - Advertising & Marketing

--- a/src/user-story/to-make-better-recommendations/index.yaml
+++ b/src/user-story/to-make-better-recommendations/index.yaml
@@ -90,7 +90,7 @@ body_content:
       *   we're able to deploy higher amount of servers in the same or even less time, due to the Jenkins Pipeline flow
 title: Jenkins is the way to make better recommendations
 date: 2020-12-27T13:51:13.000Z
-authored_by: Tidhar Klein Orbach, DevOps / Release Engineer, Taboola
+authored_by: Tidhar Klein Orbach
 post_name: to-make-better-recommendations
 quotes:
   - from: Tidhar Klein Orbach, DevOps / Release Engineer, Taboola

--- a/src/user-story/to-make-ci-easier/index.yaml
+++ b/src/user-story/to-make-ci-easier/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Guillermo Zarzuelo
   location: Spain
   industries:
     - Digital Products

--- a/src/user-story/to-make-ci-testing-management-easy-and-enjoyable/index.yaml
+++ b/src/user-story/to-make-ci-testing-management-easy-and-enjoyable/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Konstantin Starovoytov
   location: Belarus
   industries:
     - E-commerce & Retail

--- a/src/user-story/to-make-electric-vehicle-charging-possible-through-cloud/index.yaml
+++ b/src/user-story/to-make-electric-vehicle-charging-possible-through-cloud/index.yaml
@@ -71,7 +71,7 @@ body_content:
       *   Release cycles shortened from 2 weeks to every day
 title: Jenkins is the way to make electric vehicle charging possible through cloud
 date: 2021-12-14T16:11:24.000Z
-authored_by: Avinash Upadhyaya, DevOps Engineer, Hashedin by Deloitte
+authored_by: Avinash Upadhyaya
 post_name: to-make-electric-vehicle-charging-possible-through-cloud
 quotes:
   - from: Avinash Upadhyaya, DevOps Engineer, Hashedin by Deloitte

--- a/src/user-story/to-make-life-easy-and-fast/index.yaml
+++ b/src/user-story/to-make-life-easy-and-fast/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Mitchell Slotboom
   location: Netherlands
   industries:
     - Semiconductors

--- a/src/user-story/to-make-my-life-in-the-test-core-team-great-again/index.yaml
+++ b/src/user-story/to-make-my-life-in-the-test-core-team-great-again/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Martin Pokorny
   location: Austria
   industries:
     - Software Development

--- a/src/user-story/to-make-our-life-easier/index.yaml
+++ b/src/user-story/to-make-our-life-easier/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Oleh Moskovych
   location: Ukraine
   industries:
     - Information Technology

--- a/src/user-story/to-make-the-devops-process-simple-and-enjoyable/index.yaml
+++ b/src/user-story/to-make-the-devops-process-simple-and-enjoyable/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Akshit Singhal
   location: India
   industries:
     - Automotive

--- a/src/user-story/to-make-your-configuration-as-a-code-possible/index.yaml
+++ b/src/user-story/to-make-your-configuration-as-a-code-possible/index.yaml
@@ -61,7 +61,7 @@ body_content:
       ). >>"
 title: Jenkins is the way to make your configuration as a code possible
 date: 2020-06-23T01:46:35.000Z
-author: Amet Umerov, DevOps Engineer, Preply
+authored_by: Amet Umerov
 post_name: to-make-your-configuration-as-a-code-possible
 quotes:
   - from: Amet Umerov, DevOps Engineer, Preply

--- a/src/user-story/to-make-your-configuration-as-a-code-possible/index.yaml
+++ b/src/user-story/to-make-your-configuration-as-a-code-possible/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Amet Umerov
   location: Ukraine
   industries:
     - Education

--- a/src/user-story/to-make-your-work-comfortable/index.yaml
+++ b/src/user-story/to-make-your-work-comfortable/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Kanstantsin Harbachou
   location: Belarus
   industries:
     - Legal

--- a/src/user-story/to-manage-anything-and-everything-through-pipelines/index.yaml
+++ b/src/user-story/to-manage-anything-and-everything-through-pipelines/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Nitish Chandu Oggu
   location: India
   industries:
     - Financial Services

--- a/src/user-story/to-manage-minecraft-in-the-cloud/index.yaml
+++ b/src/user-story/to-manage-minecraft-in-the-cloud/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Richard Staehler III
   location: Illinois, USA
   industries:
     - Gaming

--- a/src/user-story/to-manage-your-software/index.yaml
+++ b/src/user-story/to-manage-your-software/index.yaml
@@ -29,7 +29,7 @@ body_content:
       *   No manual tasks required
 title: Jenkins is the way to manage your software
 date: 2021-09-02T14:09:38.000Z
-authored_by: Scott Meyer, Sr. Systems Analyst
+authored_by: Scott Meyer
 post_name: to-manage-your-software
 quotes:
   - from: Scott Meyer, Sr. Systems Analyst

--- a/src/user-story/to-manageable-ui-test-automation/index.yaml
+++ b/src/user-story/to-manageable-ui-test-automation/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Julio Valls
   location: Spain
   industries:
     - Consulting

--- a/src/user-story/to-migrate-telecom-applications-to-the-cloud/index.yaml
+++ b/src/user-story/to-migrate-telecom-applications-to-the-cloud/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Saikat Das
   location: India
   industries:
     - Telecomunications

--- a/src/user-story/to-modernize-healthcare/index.yaml
+++ b/src/user-story/to-modernize-healthcare/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Vitor Lobao
   location: Brazil
   industries:
     - Healthcare

--- a/src/user-story/to-modernize-your-devops-platform/index.yaml
+++ b/src/user-story/to-modernize-your-devops-platform/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Rahul Kumar
   location: India
   industries:
     - Financial Services / Payments

--- a/src/user-story/to-own-the-future/index.yaml
+++ b/src/user-story/to-own-the-future/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Ethan Collopy
   location: United Kingdom
   industries:
     - Financial Services

--- a/src/user-story/to-own-the-software-lifecycle/index.yaml
+++ b/src/user-story/to-own-the-software-lifecycle/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Vijay Sundar V
   location: India
   industries:
     - Network Communications

--- a/src/user-story/to-produce-ultra-modern-and-sophisticated-electronic-devices/index.yaml
+++ b/src/user-story/to-produce-ultra-modern-and-sophisticated-electronic-devices/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Ankit Menon
   location: India
   industries:
     - Consumer Electronics

--- a/src/user-story/to-provide-an-enterprise-grade-ci-cd-experience-to-engineers/index.yaml
+++ b/src/user-story/to-provide-an-enterprise-grade-ci-cd-experience-to-engineers/index.yaml
@@ -85,7 +85,7 @@ body_content:
       *   Teams are substantially quicker to onboard engineers into the product, since the community within our business, but also the wider Jenkins community is vibrant
 title: Jenkins is the way to provide an enterprise-grade CI/CD experience to engineers
 date: 2021-09-05T15:59:07.000Z
-authored_by: Ben Selby, Principal Engineer
+authored_by: Ben Selby
 post_name: to-provide-an-enterprise-grade-ci-cd-experience-to-engineers
 quotes:
   - from: Ben Selby, Principal Engineer

--- a/src/user-story/to-rapid-development-and-testing/index.yaml
+++ b/src/user-story/to-rapid-development-and-testing/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Gaurav Talreja
   location: India
   industries:
     - Testing

--- a/src/user-story/to-rapid-prototyping-life-science-applications/index.yaml
+++ b/src/user-story/to-rapid-prototyping-life-science-applications/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Ioannis Moutsatsos
   location: Massachusetts, USA
   industries:
     - Medical Research

--- a/src/user-story/to-reliable-automation-strategies/index.yaml
+++ b/src/user-story/to-reliable-automation-strategies/index.yaml
@@ -130,7 +130,7 @@ body_content:
       *   Automation of Java-based artifacts into Azure DataBricks.
 title: Jenkins is the way to reliable automation strategies
 date: 2021-11-19T16:35:08.000Z
-authored_by: Adrian Gramada, Technical Lead
+authored_by: Adrian Gramada
 post_name: to-reliable-automation-strategies
 quotes:
   - from: Adrian Gramada, Technical Lead

--- a/src/user-story/to-revolutionize-the-integration-of-new-technologies/index.yaml
+++ b/src/user-story/to-revolutionize-the-integration-of-new-technologies/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Cyril Tavian
   location: France
   industries:
     - Automotive

--- a/src/user-story/to-revolutionize-the-world-of-automation/index.yaml
+++ b/src/user-story/to-revolutionize-the-world-of-automation/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Daksh Jain
   location: India
   industries:
     - Information Technology
@@ -95,8 +96,7 @@ body_content:
       *   testing is incorporated within the pipeline - basically, shift left
 title: Jenkins is the way to revolutionize the world of automation
 date: 2021-08-14T13:26:07.000Z
-authored_by: Daksh Jain, Devops Enthusiast, SRM Institute of Science & Technology |
-  Linux World
+authored_by: Daksh Jain
 post_name: to-revolutionize-the-world-of-automation
 quotes:
   - from: Daksh Jain, Devops Enthusiast, SRM Institute of Science & Technology |

--- a/src/user-story/to-robot-em-all/index.yaml
+++ b/src/user-story/to-robot-em-all/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Victor Martinez
   location: Spain
   industries:
     - Software Development
@@ -87,7 +88,7 @@ body_content:
       *   Trigger builds with GitHub Comments
 title: Jenkins is the way to robot ‘em all
 date: 2020-06-17T05:06:25.000Z
-authored_by: Victor Martinez
+authored_by: Ivan Fernandez
 post_name: to-robot-em-all
 quotes:
   - from: Ivan Fernandez, Software Engineer

--- a/src/user-story/to-robot-em-all/index.yaml
+++ b/src/user-story/to-robot-em-all/index.yaml
@@ -1,6 +1,6 @@
 ---
 map:
-  authored_by: Victor Martinez
+  authored_by: Ivan Fernandez
   location: Spain
   industries:
     - Software Development

--- a/src/user-story/to-run-technical-simulations-for-developer-engineer-interviews/index.yaml
+++ b/src/user-story/to-run-technical-simulations-for-developer-engineer-interviews/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Carlos Rodriguez Lopez
   location: Spain
   industries:
     - DevOps & Human Resources

--- a/src/user-story/to-run-technical-simulations-for-developer-engineer-interviews/index.yaml
+++ b/src/user-story/to-run-technical-simulations-for-developer-engineer-interviews/index.yaml
@@ -109,7 +109,7 @@ body_content:
 title: Jenkins is the way to run technical simulations for developer/engineer
   interviews
 date: 2021-02-15T17:25:36.000Z
-authored_by: Carlos Rodriguez Lopez, Lead Support Engineer, CloudBees
+authored_by: Carlos Rodriguez Lopez
 post_name: to-run-technical-simulations-for-developer-engineer-interviews
 quotes:
   - from: Carlos Rodriguez Lopez, Lead Support Engineer, CloudBees

--- a/src/user-story/to-save-money/index.yaml
+++ b/src/user-story/to-save-money/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Leandro Martins
   location: Germany
   industries:
     - E-commerce & Retail

--- a/src/user-story/to-save-the-day/index.yaml
+++ b/src/user-story/to-save-the-day/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Eric Courville
   location: California, USA
   industries:
     - Information Technology

--- a/src/user-story/to-save-your-valuable-time/index.yaml
+++ b/src/user-story/to-save-your-valuable-time/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Abhineet Saxena
   location: India
   industries:
     - Information Technology

--- a/src/user-story/to-scale-from-the-ground-up/index.yaml
+++ b/src/user-story/to-scale-from-the-ground-up/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Francisco De Lucas
   location: Spain
   industries:
     - Financial Services
@@ -87,7 +88,7 @@ body_content:
       >](https://jenkinsistheway.io/case-studies/tymit/)"
 title: Jenkins is the way to scale from the ground up
 date: 2020-05-21T01:18:13.000Z
-authored_by: Nicolas Magnone
+authored_by: Francisco De Lucas
 post_name: to-scale-from-the-ground-up
 quotes:
   - from: Francisco De Lucas. Principal Software Engineer, Tymit

--- a/src/user-story/to-scale-your-builds/index.yaml
+++ b/src/user-story/to-scale-your-builds/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Thibaut Le Levier
   location: France
   industries:
     - Software Development

--- a/src/user-story/to-scale-your-ci-cd-pipelines/index.yaml
+++ b/src/user-story/to-scale-your-ci-cd-pipelines/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Sérgio Martins
   location: Portugal
   industries:
     - Fashion

--- a/src/user-story/to-simplify-the-cloud-onboarding-process/index.yaml
+++ b/src/user-story/to-simplify-the-cloud-onboarding-process/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Ant Kenworthy
   location: United Kingdom
   industries:
     - Government

--- a/src/user-story/to-simplify-things-for-devops-world/index.yaml
+++ b/src/user-story/to-simplify-things-for-devops-world/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Prudviraj Pentakota
   location: India
   industries:
     - Software Developement

--- a/src/user-story/to-space/index.yaml
+++ b/src/user-story/to-space/index.yaml
@@ -1,6 +1,6 @@
 ---
 map:
-  authored_by: Marcin Drobik
+  authored_by: Maciej Nowak
   location: Poland
   industries:
     - Aerospace

--- a/src/user-story/to-space/index.yaml
+++ b/src/user-story/to-space/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Marcin Drobik
   location: Poland
   industries:
     - Aerospace

--- a/src/user-story/to-speed-up-the-product-development-process/index.yaml
+++ b/src/user-story/to-speed-up-the-product-development-process/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Erana Chandran
   location: India
   industries:
     - Information Technology
@@ -108,7 +109,7 @@ body_content:
       *   Getting Jenkins build results in Microsoft Teams
 title: Jenkins is the way to speed up the product development process
 date: 2021-04-21T14:50:12.000Z
-authored_by: Erana Chandran, DevOps Engineer in Information Technology
+authored_by: Erana Chandran
 post_name: to-speed-up-the-product-development-process
 quotes:
   - from: Erana Chandran, DevOps Engineer in Information Technology

--- a/src/user-story/to-speed-up-the-world/index.yaml
+++ b/src/user-story/to-speed-up-the-world/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Pablo Del Giudice
   location: Argentina
   industries:
     - Financial Services

--- a/src/user-story/to-successfully-deploy-enterprise-level-applications/index.yaml
+++ b/src/user-story/to-successfully-deploy-enterprise-level-applications/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Debobrata Bose
   location: India
   industries:
     - Financial Services

--- a/src/user-story/to-tackle-any-challenge/index.yaml
+++ b/src/user-story/to-tackle-any-challenge/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Mark Baumann
   location: Germany
   industries:
     - Software Development

--- a/src/user-story/to-take-the-pressure-off-your-dev-teams/index.yaml
+++ b/src/user-story/to-take-the-pressure-off-your-dev-teams/index.yaml
@@ -72,7 +72,7 @@ body_content:
       *   nearly elimination of custom build scripts in favor of standardized wide scope solutions
 title: Jenkins is the way to take the pressure off your dev teams
 date: 2020-08-07T19:02:49.000Z
-author: Peter Carenza, DevOps Specialist
+authored_by: Peter Carenza
 post_name: to-take-the-pressure-off-your-dev-teams
 quotes:
   - from: Peter Carenza, DevOps Specialist

--- a/src/user-story/to-take-the-pressure-off-your-dev-teams/index.yaml
+++ b/src/user-story/to-take-the-pressure-off-your-dev-teams/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Peter Carenza
   location: Chattanooga, Tennessee, USA
   industries:
     - Healthcare

--- a/src/user-story/to-test-software-packages-overnight/index.yaml
+++ b/src/user-story/to-test-software-packages-overnight/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Mallanna Biradar
   location: India
   industries:
     - Semiconductors

--- a/src/user-story/to-transform-server-build-automation/index.yaml
+++ b/src/user-story/to-transform-server-build-automation/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Jon Wright
   location: Colorado, USA
   industries:
     - Information Technology

--- a/src/user-story/to-transformation/index.yaml
+++ b/src/user-story/to-transformation/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Shyam Thadichetti
   location: India
   industries:
     - Healthcare

--- a/src/user-story/to-truly-automate-everything/index.yaml
+++ b/src/user-story/to-truly-automate-everything/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: V Roshan Kumar Patro
   location: India
   industries:
     - Information Technology

--- a/src/user-story/to-understand-and-simplify-your-software-workflows-2/index.yaml
+++ b/src/user-story/to-understand-and-simplify-your-software-workflows-2/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Javier Méndez Veira
   location: Spain
   industries:
     - Education

--- a/src/user-story/to-understand-and-simplify-your-software-workflows/index.yaml
+++ b/src/user-story/to-understand-and-simplify-your-software-workflows/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Koen Poppe
   location: Belgium
   industries:
     - DevOps & Machine Learning

--- a/src/user-story/to-write-awesome-code/index.yaml
+++ b/src/user-story/to-write-awesome-code/index.yaml
@@ -1,5 +1,6 @@
 ---
 map:
+  authored_by: Johannes Mayer
   location: Germany
   industries:
     - Binary Translation


### PR DESCRIPTION
Fixes #94 

## Description : 

-This PR restores the correct authored_by values in some of  the affected YAML files, fixing the metadata mismatches introduced in:

PR #80 – Combined name and submitted_by into authored_by, but mistakenly altered some values.
PR #91 – Reintroduced authored_by in map popups but retained incorrect author names.

-Additionally, this PR corrects author names in the map, resolving issues carried over from PR #91.

## Cause : 

-During PR #80, some author names were accidentally deleted while resolving merge conflicts.
-IDE automation (auto-tab/formatting) unintentionally misplaced author values in multiple YAML files.
-As a result, PR #91 also inherited incorrect author data, affecting both the YAML files and the map display.


## Changes Made:

✅ Corrected authored_by fields for stories where author names were misplaced.
✅ Cross-checked with commit history (418787b and earlier) to restore original author attributions.
✅ Verified that each story now reflects its correct author metadata.
✅ Restored correct authored_by values in the map.
✅ Ensured the map now displays the proper author names.

### The issue was referenced in the comment https://github.com/jenkins-infra/stories/pull/91#issuecomment-2624074392



Please review the changes to ensure all corrections align with the original submissions.
If any further improvements  are needed , I will address them promptly.
Thank you for your patience and guidance! 