### PR TITLE
feat: add `Probot-Autolabeler` configuration for documentation

### DIFF
--- a/.github/autolabeler.yml
+++ b/.github/autolabeler.yml
@@ -1,0 +1,3 @@
+documentation:
+  - README.md
+  - src/user-story/**/*.yaml

--- a/.github/autolabeler.yml
+++ b/.github/autolabeler.yml
@@ -1,3 +1,1 @@
-documentation:
-  - README.md
-  - src/user-story/**/*.yaml
+documentation: ["README.md", "src/user-story/**/*.yaml"]

--- a/.github/autolabeler.yml
+++ b/.github/autolabeler.yml
@@ -1,1 +1,1 @@
-documentation: ["README.md", "src/user-story/**/*.yaml"]
+documentation: ["README.md"]


### PR DESCRIPTION
#### Fixes #100 

- Sub-part of the issue #100

### Description : 

- This PR introduces a configuration file for Probot-Autolabeler to automate labeling of Pull Requests related to documentation updates.

### Key Details:

- The documentation label is applied to PRs that modify:

1.  README.md file .
2. All `yaml` files .