### PR TITLE
Fix logo overflow issue in mobile view (≤375px)

### DIFF
--- a/src/pages/index.css
+++ b/src/pages/index.css
@@ -73,7 +73,7 @@
 }
 
 .hero-image {
-  width: 350px;
+  max-width: 350px;
   margin: 20px auto;
   border-radius: 10px;
   box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);


### PR DESCRIPTION
## PR Description:
This PR fixes the issue where the "Jenkins Is the Way" logo overflows its container on small screens (≤375px).

## Changes Made:
Prevented horizontal overflow by changing the width property to max-width.
Tested on 375px and 320px mobile screen sizes.

## Screenshots:
### Before (Bug):
![screen-375px](https://github.com/user-attachments/assets/6e8c525d-0c16-41e0-b2ad-686ffaf22287)
![screen-320px](https://github.com/user-attachments/assets/a84ea0bf-8c90-4fbb-a34c-521e2fc8fc6f)

### After (Fixed):
![after-375px](https://github.com/user-attachments/assets/c96b6b72-3d93-4817-836b-56d766f41a2f)
![after-320px](https://github.com/user-attachments/assets/2d13e4fc-fa25-4e19-b69b-0cd2667e0a29)

## Linked Issue:
Closes #107 

