### PR TITLE
fix: patch light mode no longer supported issue

### DIFF
--- a/src/components/StatsCard.jsx
+++ b/src/components/StatsCard.jsx
@@ -10,7 +10,7 @@ const StatBox = ({ value, label }) => (
 
 const StatsCard = ({ totalStories, uniqueLocations, uniqueIndustries }) => {
   return (
-    <div className={`${styles.statsCard} bg-dark`}>
+    <div className={`${styles.statsCard}`}>
       <div className={styles.statsContainer}>
         <StatBox value={totalStories} label="Stories" />
         <StatBox value={uniqueLocations} label="Locations" />

--- a/src/components/StatsCard.module.css
+++ b/src/components/StatsCard.module.css
@@ -21,7 +21,11 @@
   transition: transform 0.2s ease-in-out;
   position: relative;
 }
-
+@media (prefers-color-scheme: light) {
+  .statBox{
+    background-color: white;
+  }
+} 
 .statBox:hover {
   transform: translateY(-4px);
 }
@@ -32,7 +36,11 @@
   color: #ffffff;
   margin-bottom: 8px;
 }
-
+@media (prefers-color-scheme: light) {
+  .statValue{
+    color: black;
+  }
+} 
 .statLabel {
   font-size: 14px;
   font-weight: 400;

--- a/src/components/UserStory.jsx
+++ b/src/components/UserStory.jsx
@@ -64,7 +64,7 @@ const UserStory = ({
       <div className="row">
         <div className="col">
           <div className="container pb-2">
-            <h1>{tag_line}</h1>
+            <h1 className='textcolor'>{tag_line}</h1>
           </div>
 
           <div className="container pt-2 pb-2">

--- a/src/components/UserStoryCard.module.css
+++ b/src/components/UserStoryCard.module.css
@@ -9,7 +9,12 @@
   margin: 1.5rem;
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
 }
-
+@media (prefers-color-scheme: light) {
+  .card {
+    border: 1px solid #7e7e7e;
+    background-color: white;
+  }
+} 
 .card:hover {
   transform: translateY(-4px);
   box-shadow: 0 6px 12px rgba(0, 0, 0, 0.3);
@@ -53,7 +58,11 @@
   margin: 0;
   line-height: 1.4;
 }
-
+@media (prefers-color-scheme: light) {
+  .title {
+     color: black;
+  }
+} 
 .date {
   color: #888;
   font-size: 0.875rem;
@@ -80,6 +89,12 @@
   padding: 0.5rem 0.75rem;
   align-self: flex-start;
 }
+@media (prefers-color-scheme: light) {
+  .readMore {
+    border: 1px solid black;
+     color: black;
+  }
+} 
 
 .readMore:hover {
   color: #60a5fa;

--- a/src/pages/MapPage.css
+++ b/src/pages/MapPage.css
@@ -1,8 +1,4 @@
 /* Base styles */
-body {
-  background-color: #121212;
-  color: #ffffff;
-}
 
 h1 {
   font-size: 2.5rem;
@@ -134,6 +130,12 @@ h3 {
   overflow: hidden;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
 }
+@media (prefers-color-scheme: light) {
+  .story-popup  {
+    background-color: #ffffff;
+    color: black;
+  }
+} 
 
 .story-img {
   width: 120px !important; 
@@ -168,6 +170,11 @@ h3 {
   -webkit-box-orient: vertical;
   overflow: hidden;
 }
+@media (prefers-color-scheme: light) {
+  .story-popup-title {
+    color: black;
+  }
+} 
 
 .story-popup-details {
   margin-bottom: 0.5rem;
@@ -188,12 +195,22 @@ h3 {
   flex-shrink: 0;
   font-size: 14px;
 }
+@media (prefers-color-scheme: light) {
+  .story-popup-label {
+    color: black;
+  }
+} 
 
 .story-popup-value {
   color: #e0e0e0;
   font-size: 14px;
   flex-grow: 1;
 }
+@media (prefers-color-scheme: light) {
+  .story-popup-value {
+    color: rgb(39, 39, 39);
+  }
+} 
 
 .story-btn-container {
   display: flex;
@@ -216,11 +233,22 @@ h3 {
   width: fit-content;
   transition: background-color 0.2s ease-in-out;
 }
+@media (prefers-color-scheme: light) {
+  .story-popup-button{
+    background-color: #e0e0e0;
+    color: black;
+  }
+} 
 
 .story-popup-button:hover {
   transform: translateY(-3px);
   color: white !important;
 }
+@media (prefers-color-scheme: light) {
+  .story-popup-button:hover{
+    color: black !important;
+  }
+} 
 
 /* Override Leaflet default popup styles */
 .leaflet-popup-content-wrapper {

--- a/src/pages/all.jsx
+++ b/src/pages/all.jsx
@@ -33,12 +33,12 @@ const AllPage = () => {
       <div className="container">
         <div className="row body">
           <div className="col text-center">
-            <h1>Jenkins Is The Way</h1>
+            <h1 className='textcolor'>Jenkins Is The Way</h1>
           </div>
         </div>
         <div className="row">
           <div className="col">
-            <h2>Tell Your Story</h2>
+            <h2 className='textcolor'>Tell Your Story</h2>
             <p>
               &quot;Jenkins Is The Way&quot; is a global showcase of how
               developers and engineers are building, deploying, and automating

--- a/src/pages/index.css
+++ b/src/pages/index.css
@@ -1,4 +1,23 @@
 /* Default (Dark Mode) */
+body, html {
+  background-color: #121212;
+}
+
+@media (prefers-color-scheme: light) {
+  body, html {
+    background-color: white;
+  }
+} 
+.textcolor {
+  color: white;
+}
+
+@media (prefers-color-scheme: light) {
+  .textcolor {
+    color: black;
+  }
+} 
+
 :root {
   --background-gradient: linear-gradient(
     145deg,

--- a/src/pages/map.jsx
+++ b/src/pages/map.jsx
@@ -127,7 +127,7 @@ const MapPage = () => {
       <Seo title={title} pathname="/" />
       <div className="container">
         <div className="row text-center">
-          <div className="col ">
+          <div className="col">
             <h1 className='textcolor'>Jenkins Is The Way</h1>
             <h2 className='textcolor'>Latest Jenkins User Stories</h2>
             {/* Stats Section */}

--- a/src/pages/map.jsx
+++ b/src/pages/map.jsx
@@ -127,9 +127,9 @@ const MapPage = () => {
       <Seo title={title} pathname="/" />
       <div className="container">
         <div className="row text-center">
-          <div className="col">
-            <h1>Jenkins Is The Way</h1>
-            <h2>Latest Jenkins User Stories</h2>
+          <div className="col ">
+            <h1 className='textcolor'>Jenkins Is The Way</h1>
+            <h2 className='textcolor'>Latest Jenkins User Stories</h2>
             {/* Stats Section */}
             <StatsCard
               totalStories={totalStories}


### PR DESCRIPTION
fixes #128 

## What was the issue?
the issue was mainly in the mapPage.css
where the contributor uses 
```js
body {
  background-color: #121212;
  color: #ffffff;
}
```
which made the overall page color static and overlaps the theme.

## solution
we uses the theme to dynamically change the color base on it. 

## Screenshot
<img width="1512" alt="Screenshot 2025-03-01 at 3 59 08 PM" src="https://github.com/user-attachments/assets/7eb1b64a-d537-4b2a-8486-ec9a3ee9edca" />
<img width="1512" alt="Screenshot 2025-03-01 at 3 59 14 PM" src="https://github.com/user-attachments/assets/7a64c286-3d68-419b-8ede-70e71ba54218" />
<img width="1512" alt="Screenshot 2025-03-01 at 3 59 26 PM" src="https://github.com/user-attachments/assets/f7183306-3a6a-4368-b454-8f916f92ea47" />

## Result
now the repo support both dark and light theme