### PR TITLE
fixup: remove client name and set organization

### DIFF
--- a/src/user-story/to-allow-people-to-self-service-help-launch-stuff-stabilize-releases-and-encourage-developers/index.yaml
+++ b/src/user-story/to-allow-people-to-self-service-help-launch-stuff-stabilize-releases-and-encourage-developers/index.yaml
@@ -2,7 +2,7 @@
 metadata:
   title: A digital agency in Munich finds a better way to serve clients through
     faster and more accurate builds using Jenkins.
-  organization: German Digital Agency
+  organization: Bestbytes
   industries:
     - Webshop / Webstore
   programming_languages:
@@ -91,4 +91,4 @@ quotes:
       providing us the tools needed to rock releases and automated tasks!
     image: ./quote.png
 image: noun_Digital-Agency_1275969.png
-tag_line: Globus Automation Magic
+tag_line: Morning Automation Magic


### PR DESCRIPTION
I'd love to omit the company name from the title, and add the organization!