### PR TITLE
Fix error in `to-build-for-the-future` page

### DIFF
--- a/src/user-story/to-build-for-the-future/index.yaml
+++ b/src/user-story/to-build-for-the-future/index.yaml
@@ -8,20 +8,25 @@ map:
 metadata:
   title: Jenkins gave this IT team the tools they needed to revamp their client's
     healthcare platform.
+  organization: "Development project for a healthcare company"
+  programming_languages:
+    - Java
+  platforms:
+    - Docker
+    - Kubernetes
+    - Linux
   version_control_systems:
     - GitHub
     - Subversion
   build_tools:
     - Ant
     - Maven
+  community_supports: 
+    - Jenkins.io websites & blogs
 body_content:
   title: Transition off an old, slow and manual build system to something built
     for the future.
   paragraphs:
-    - \*\**Organization:* \*\*Development project for a healthcare company
-    - \*\**Programming Language:* \*\*Java
-    - "***Platform***\\*:\\* Docker or Kubernetes, Linux"
-    - \*\**Community Support:* \*\*Jenkins.io websites & blogs
     - "**Background:** A healthcare company reached out to this IT group because
       they needed to have a faster way to build, test, and deploy applications,
       while automating as much of the testing and quality checks as possible.


### PR DESCRIPTION
link: https://stories.jenkins.io/user-story/to-build-for-the-future/

# Earlier 
<img width="999" height="834" alt="image" src="https://github.com/user-attachments/assets/dcdebd42-3e2f-45aa-b3bb-783d935633be" />

# Now 
<img width="1421" height="706" alt="image" src="https://github.com/user-attachments/assets/3bdabdcb-245f-48c4-92c4-4e14308bf25e" />
