### PR TITLE
Adding new chore, dependency auto-labels

### DIFF
--- a/.github/autolabeler.yml
+++ b/.github/autolabeler.yml
@@ -1,1 +1,3 @@
 documentation: ["README.md"]
+chore: [".github", "Jenkinsfile", "package.json", "package-lock.json"]
+dependencies: ["package.json", "package-lock.json"]


### PR DESCRIPTION
I think these lables should be helpful. We have renovate installed in this repo. So, for every PR made by renovate, we have to manually add `chore` & `dependency` label. 