### PR TITLE
fix: change `jenkins-infra/jenkins.io` to `jenkins-infra/stories` in compress-images.yaml

### DIFF
--- a/.github/workflows/compress-images.yaml
+++ b/.github/workflows/compress-images.yaml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     # Only run on main repo on and PRs that match the main repo.
     if: |
-      github.repository == 'jenkins-infra/jenkins.io' &&
+      github.repository == 'jenkins-infra/stories' &&
       (github.event_name != 'pull_request' ||
        github.event.pull_request.head.repo.full_name == github.repository)
     steps:


### PR DESCRIPTION
Currently, It was skipping the job because the workflow was pointing to jenkins.io instead of /stories.
Now, I've changed it to /stories such that it shows the expected result.

<img width="1487" height="576" alt="image" src="https://github.com/user-attachments/assets/394aaa12-ae95-4e38-b13b-1dadf7637cff" />
