### PR TITLE
fix: correct truncated "& Retail" industry value

### DIFF
--- a/src/user-story/to-build-a-scalable-ci-cd-orchestration-platform/index.yaml
+++ b/src/user-story/to-build-a-scalable-ci-cd-orchestration-platform/index.yaml
@@ -13,7 +13,7 @@ metadata:
   industries:
     - Finance
     - Healthcare
-    - "& Retail"
+    - E-commerce & Retail
   programming_languages:
     - HashiCorp Configuration Language (HCL)
   platforms:


### PR DESCRIPTION
This PR fixes #350

## Problem

The industry filter dropdown on https://stories.jenkins.io/map/ was displaying "& Retail" instead of a proper industry name.

## Root Cause

In the story file `to-build-a-scalable-ci-cd-orchestration-platform/index.yaml`, the industry value was incorrectly stored as `"& Retail"` - which appears to be a truncated version of the standard industry tag `"E-commerce & Retail"`.

## Solution

Changed the truncated `"& Retail"` to the full `"E-commerce & Retail"` value to match the convention used elsewhere in the repository.

## File Changed

- `src/user-story/to-build-a-scalable-ci-cd-orchestration-platform/index.yaml`

Fixes #350