### PR TITLE
fix: modify "& Retail" to "E-commerce & Retail"

### DIFF
--- a/src/user-story/to-build-a-scalable-ci-cd-orchestration-platform/index.yaml
+++ b/src/user-story/to-build-a-scalable-ci-cd-orchestration-platform/index.yaml
@@ -13,7 +13,7 @@ metadata:
   industries:
     - Finance
     - Healthcare
-    - "& Retail"
+    - "E-commerce & Retail"
   programming_languages:
     - HashiCorp Configuration Language (HCL)
   platforms:


### PR DESCRIPTION
### Problem
The industry filter dropdown on [Map](https://stories.jenkins.io/map/) was showing "& Retail" instead of the correct industry name.

### Cause
In the file `to-build-a-scalable-ci-cd-orchestration-platform/index.yaml`, the industry field was saved as "& Retail", which is an incomplete version of the correct tag "E-commerce & Retail".

### Fix
Updated the industry value from "& Retail" to "E-commerce & Retail" to keep it consistent with the other industry tags in the repository.

### Screenshot
<img width="261" height="27" alt="image" src="https://github.com/user-attachments/assets/8a80a04d-08e9-42ba-af32-f94f5fbbb753" />

### File Updated
`src/user-story/to-build-a-scalable-ci-cd-orchestration-platform/index.yaml`

Fixes #350 