### PR TITLE
fix: remove stray '&' from Retail industry label

### DIFF
--- a/src/user-story/to-build-a-scalable-ci-cd-orchestration-platform/index.yaml
+++ b/src/user-story/to-build-a-scalable-ci-cd-orchestration-platform/index.yaml
@@ -13,7 +13,7 @@ metadata:
   industries:
     - Finance
     - Healthcare
-    - "& Retail"
+    - Retail
   programming_languages:
     - HashiCorp Configuration Language (HCL)
   platforms:


### PR DESCRIPTION
## Summary\n- fixes #350\n- updates the industry tag for the affected story from `"& Retail"` to `Retail`\n- keeps taxonomy consistent with other Retail entries in the dataset\n\n## Validation\n- npm run lint\n- YAML file parses successfully