### PR TITLE
fix(cms): fix external user open authoring workflow

### DIFF
--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -2,7 +2,6 @@ backend:
   name: github
   repo: jenkins-infra/stories
   branch: main
-  use_graphql: true
   site_domain: stories.jenkins.io
   open_authoring: true
 


### PR DESCRIPTION
# Fix external user open authoring workflow (#4392)

## Description

This PR fixes [Issue #4392](https://github.com/jenkins-infra/helpdesk/issues/4392), where external users (non-members of `jenkins-infra`) encounter permission errors when trying to submit user stories via Netlify/Decap CMS's `open_authoring` workflow.

### The Root Cause

When `use_graphql: true` is enabled in the CMS configuration, the [decap-cms-backend-github](cci:7://file:///Users/pratham/Desktop/project/stories/node_modules/decap-cms/node_modules/decap-cms-backend-github:0:0-0:0) package attempts to use GitHub's GraphQL API (`createRef` mutation) to create the draft branch. However, this mutation natively targets the **origin repository** (`jenkins-infra/stories`) rather than properly executing against the user's localized fork.

Since external users do not have write access to the origin repository, GitHub rejects the GraphQL mutation. Furthermore, because the Jenkins organization restricts third-party OAuth access, external GraphQL requests are blocked entirely.

### The Fix

I have removed `use_graphql: true` from [static/admin/config.yml](cci:7://file:///Users/pratham/Desktop/project/stories/static/admin/config.yml:0:0-0:0).

By disabling this flag, Decap CMS gracefully falls back to the GitHub REST API implementation. The REST API correctly identifies the external user's permissions, interacts directly with their personal fork, and successfully opens the PR without violating the origin repo's security constraints or GraphQL limitations.

## Verification
- [x] Verified locally by spinning up the Gatsby dev server and confirming that the CMS Login workflow bypasses the GraphQL error and redirects seamlessly to the standard GitHub OAuth authorization.
