### PR TITLE
feat(ci): add broken link checker GitHub Action

### DIFF
--- a/.github/workflows/broken-links.yml
+++ b/.github/workflows/broken-links.yml
@@ -1,0 +1,35 @@
+name: Broken link checker
+
+on:
+  pull_request:
+    paths:
+      - '**/*.md'
+      - '**/*.mdx'
+      - '**/*.yml'
+      - '**/*.yaml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  lychee:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run lychee
+        uses: lycheeverse/lychee-action@v2
+        with:
+          fail: true
+          args: >-
+            --no-progress
+            --verbose
+            --exclude-mail
+            --accept 200,429
+            --include-fragments
+            '**/*.md'
+            '**/*.mdx'
+            '**/*.yml'
+            '**/*.yaml'


### PR DESCRIPTION
### Description
Add a CI workflow that runs Lychee to detect broken links in markdown and YAML files.

### Fixes
Fixes #339

### Screen Shots (if any)
N/A (CI workflow change only)

### Submitter checklist
- [x] Descriptive PR title and meaningful summary
- [x] Changes align with project conventions
- [x] No unrelated changes included
- [x] Documentation updated (if needed)

### Additional Context
- Triggered on pull requests that touch `.md`, `.mdx`, `.yml`, or `.yaml` files.
- Supports manual runs via `workflow_dispatch`.
- Uses `lycheeverse/lychee-action@v2` with `--exclude-mail` and fragment checks enabled.
- Uses `--accept 200,429` to reduce false negatives when endpoints are rate-limited.
