### PR TITLE
test(map): add unit coverage for filtering and GeoJSON center logic

### DIFF
--- a/src/components/StoriesMap.jsx
+++ b/src/components/StoriesMap.jsx
@@ -9,6 +9,14 @@ import * as styles from './StoriesMap.module.css';
 import 'leaflet.markercluster';
 import 'leaflet.markercluster/dist/MarkerCluster.css';
 import 'leaflet.markercluster/dist/MarkerCluster.Default.css';
+import {
+  extractCountry,
+  filterStories,
+  groupStoriesByCountry,
+  getCenterForCountry,
+  DEFAULT_MAP_CENTER,
+  DEFAULT_MAP_ZOOM,
+} from '../utils/storiesMap.mjs';
 
 // Component to handle map view changes
 const ChangeView = ({ center, zoom }) => {
@@ -88,16 +96,6 @@ const StoriesMap = ({ mapPin }) => {
     story => story.map && story.map.geojson && story.map.location,
   );
 
-  // Helper function to extract country from location string
-  function extractCountry(location) {
-    if (!location) return 'Unknown';
-    const parts = location.split(',');
-    if (parts.length > 1) {
-      return parts[parts.length - 1].trim();
-    }
-    return location.trim();
-  }
-
   const allCountries = useMemo(() => {
     const countries = storiesWithLocation.map(story =>
       extractCountry(story.map.location),
@@ -120,23 +118,16 @@ const StoriesMap = ({ mapPin }) => {
   }, [storiesWithLocation]);
 
   // Group stories by country
-  const storiesByCountry = useMemo(() => {
-    return storiesWithLocation.reduce((acc, story) => {
-      const country = extractCountry(story.map.location);
-
-      if (!acc[country]) {
-        acc[country] = [];
-      }
-      acc[country].push(story);
-      return acc;
-    }, {});
-  }, [storiesWithLocation]);
+  const storiesByCountry = useMemo(
+    () => groupStoriesByCountry(storiesWithLocation),
+    [storiesWithLocation],
+  );
 
   const [selectedCountry, setSelectedCountry] = useState(null);
   const [selectedIndustry, setSelectedIndustry] = useState(null);
   const [searchQuery, setSearchQuery] = useState('');
-  const [mapCenter, setMapCenter] = useState([20, 0]); // Default center
-  const [mapZoom, setMapZoom] = useState(2); // Default zoom
+  const [mapCenter, setMapCenter] = useState(DEFAULT_MAP_CENTER);
+  const [mapZoom, setMapZoom] = useState(DEFAULT_MAP_ZOOM);
   const [showFilters, setShowFilters] = useState(false);
 
   // Avoid hydration mismatch
@@ -146,70 +137,31 @@ const StoriesMap = ({ mapPin }) => {
   }, []);
 
   // Filter stories based on selected criteria
-  const filteredStories = useMemo(() => {
-    return storiesWithLocation.filter(story => {
-      // Filter by country if selected
-      if (selectedCountry && !story.map.location.includes(selectedCountry)) {
-        return false;
-      }
-
-      // Filter by industry if selected
-      if (
-        selectedIndustry &&
-        (!story.metadata?.industries ||
-          !story.metadata.industries.includes(selectedIndustry))
-      ) {
-        return false;
-      }
-
-      // prefix-based country search
-      if (searchQuery) {
-        const query = searchQuery.toLowerCase().trim();
-        const country = extractCountry(story.map.location).toLowerCase();
-        return country.startsWith(query);
-      }
-
-      return true;
-    });
-  }, [storiesWithLocation, selectedCountry, selectedIndustry, searchQuery]);
+  const filteredStories = useMemo(
+    () =>
+      filterStories(storiesWithLocation, {
+        selectedCountry,
+        selectedIndustry,
+        searchQuery,
+      }),
+    [storiesWithLocation, selectedCountry, selectedIndustry, searchQuery],
+  );
 
   // Handle country selection
   const handleCountrySelect = country => {
     if (selectedCountry === country) {
       // If clicking the same country, deselect it
       setSelectedCountry(null);
-      setMapCenter([20, 0]);
-      setMapZoom(2);
+      setMapCenter(DEFAULT_MAP_CENTER);
+      setMapZoom(DEFAULT_MAP_ZOOM);
     } else {
       setSelectedCountry(country);
 
-      // Calculate average lat/lng for the country to center the map
       const stories = storiesByCountry[country];
       if (stories && stories.length > 0) {
-        let totalLat = 0;
-        let totalLng = 0;
-        let validCoords = 0;
-
-        stories.forEach(story => {
-          try {
-            const geojson = JSON.parse(story.map.geojson);
-            if (
-              geojson &&
-              geojson.coordinates &&
-              geojson.coordinates.length >= 2
-            ) {
-              const [longitude, latitude] = geojson.coordinates;
-              totalLat += latitude;
-              totalLng += longitude;
-              validCoords++;
-            }
-          } catch (e) {
-            console.error('Error parsing geojson:', e);
-          }
-        });
-
-        if (validCoords > 0) {
-          setMapCenter([totalLat / validCoords, totalLng / validCoords]);
+        const center = getCenterForCountry(stories);
+        if (center) {
+          setMapCenter(center);
           setMapZoom(5); // Zoom in when a country is selected
         }
       }
@@ -221,8 +173,8 @@ const StoriesMap = ({ mapPin }) => {
     setSelectedCountry(null);
     setSelectedIndustry(null);
     setSearchQuery('');
-    setMapCenter([20, 0]);
-    setMapZoom(2);
+    setMapCenter(DEFAULT_MAP_CENTER);
+    setMapZoom(DEFAULT_MAP_ZOOM);
   };
 
   return (

--- a/src/utils/storiesMap.mjs
+++ b/src/utils/storiesMap.mjs
@@ -1,0 +1,76 @@
+export const DEFAULT_MAP_CENTER = [20, 0];
+export const DEFAULT_MAP_ZOOM = 2;
+
+export function extractCountry(location) {
+  if (!location) return 'Unknown';
+  const parts = location.split(',');
+  if (parts.length > 1) {
+    return parts[parts.length - 1].trim();
+  }
+  return location.trim();
+}
+
+export function groupStoriesByCountry(stories) {
+  return stories.reduce((acc, story) => {
+    const country = extractCountry(story.map.location);
+    if (!acc[country]) {
+      acc[country] = [];
+    }
+    acc[country].push(story);
+    return acc;
+  }, {});
+}
+
+export function filterStories(
+  stories,
+  { selectedCountry = null, selectedIndustry = null, searchQuery = '' } = {},
+) {
+  const query = searchQuery.toLowerCase().trim();
+
+  return stories.filter(story => {
+    if (selectedCountry && !story.map.location.includes(selectedCountry)) {
+      return false;
+    }
+
+    if (
+      selectedIndustry &&
+      (!story.metadata?.industries ||
+        !story.metadata.industries.includes(selectedIndustry))
+    ) {
+      return false;
+    }
+
+    if (query) {
+      const country = extractCountry(story.map.location).toLowerCase();
+      return country.startsWith(query);
+    }
+
+    return true;
+  });
+}
+
+export function getCenterForCountry(stories = []) {
+  let totalLat = 0;
+  let totalLng = 0;
+  let validCoords = 0;
+
+  stories.forEach(story => {
+    try {
+      const geojson = JSON.parse(story.map.geojson);
+      if (geojson && geojson.coordinates && geojson.coordinates.length >= 2) {
+        const [longitude, latitude] = geojson.coordinates;
+        totalLat += latitude;
+        totalLng += longitude;
+        validCoords++;
+      }
+    } catch {
+      // ignore malformed geojson entries
+    }
+  });
+
+  if (validCoords === 0) {
+    return null;
+  }
+
+  return [totalLat / validCoords, totalLng / validCoords];
+}

--- a/test/storiesMap.test.mjs
+++ b/test/storiesMap.test.mjs
@@ -1,0 +1,74 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  extractCountry,
+  groupStoriesByCountry,
+  filterStories,
+  getCenterForCountry,
+} from '../src/utils/storiesMap.mjs';
+
+const stories = [
+  {
+    id: '1',
+    map: {
+      location: 'Paris, France',
+      geojson: JSON.stringify({ type: 'Point', coordinates: [2.3522, 48.8566] }),
+    },
+    metadata: { industries: ['Finance'] },
+  },
+  {
+    id: '2',
+    map: {
+      location: 'Lyon, France',
+      geojson: JSON.stringify({ type: 'Point', coordinates: [4.8357, 45.764] }),
+    },
+    metadata: { industries: ['Retail'] },
+  },
+  {
+    id: '3',
+    map: {
+      location: 'Berlin, Germany',
+      geojson: JSON.stringify({ type: 'Point', coordinates: [13.405, 52.52] }),
+    },
+    metadata: { industries: ['Finance'] },
+  },
+];
+
+test('extractCountry extracts trailing country from location', () => {
+  assert.equal(extractCountry('Paris, France'), 'France');
+  assert.equal(extractCountry('France'), 'France');
+  assert.equal(extractCountry(''), 'Unknown');
+});
+
+test('groupStoriesByCountry groups stories by extracted country', () => {
+  const grouped = groupStoriesByCountry(stories);
+  assert.equal(grouped.France.length, 2);
+  assert.equal(grouped.Germany.length, 1);
+});
+
+test('filterStories supports country, industry, and prefix search', () => {
+  const byCountry = filterStories(stories, { selectedCountry: 'France' });
+  assert.equal(byCountry.length, 2);
+
+  const byIndustry = filterStories(stories, { selectedIndustry: 'Retail' });
+  assert.equal(byIndustry.length, 1);
+  assert.equal(byIndustry[0].id, '2');
+
+  const byPrefix = filterStories(stories, { searchQuery: 'ger' });
+  assert.equal(byPrefix.length, 1);
+  assert.equal(byPrefix[0].id, '3');
+});
+
+test('getCenterForCountry averages valid geojson points and ignores malformed entries', () => {
+  const center = getCenterForCountry([
+    stories[0],
+    stories[1],
+    { map: { geojson: '{invalid json}' } },
+  ]);
+
+  assert.ok(center);
+  assert.equal(center.length, 2);
+  assert.equal(Number(center[0].toFixed(4)), 47.3103);
+  assert.equal(Number(center[1].toFixed(4)), 3.5939);
+});


### PR DESCRIPTION
### Description
- extract map-specific data helpers (`extractCountry`, grouping, filtering, and center calculation) into a dedicated utility module
- keep `StoriesMap` behavior unchanged while making the data logic testable in isolation
- add Node.js unit tests that cover country extraction, grouping, filter combinations, and malformed GeoJSON handling

### Fixes
Fixes #327

### Screen Shots (if any)
N/A (no visual changes)

### Submitter checklist
- [x] Descriptive PR title and meaningful summary
- [x] Changes align with project conventions
- [x] No unrelated changes included
- [x] Documentation updated (if needed)

### Additional Context
- targeted validation run: `node --test test/storiesMap.test.mjs`
- eslint could not be executed in this ephemeral environment because project dependencies were not installed (`eslint: command not found`)
