### PR TITLE
fix(map): remove stray ampersand from Retail industry

### DIFF
--- a/src/user-story/to-build-a-scalable-ci-cd-orchestration-platform/index.yaml
+++ b/src/user-story/to-build-a-scalable-ci-cd-orchestration-platform/index.yaml
@@ -13,7 +13,7 @@ metadata:
   industries:
     - Finance
     - Healthcare
-    - "& Retail"
+    - Retail
   programming_languages:
     - HashiCorp Configuration Language (HCL)
   platforms:


### PR DESCRIPTION
### Description
Remove the stray `&` prefix from the `Retail` industry value used by the map filters.

### Fixes
Fixes #350

### Screen Shots (if any)
N/A (single data-value correction)

### Submitter checklist

- [x] Descriptive PR title and meaningful summary
- [x] Changes align with project conventions
- [x] No unrelated changes included
- [x] Documentation updated (if needed)

### Additional Context
Targeted validation run locally:
- `git diff --check`
- `grep -n '"& Retail"' src/user-story/to-build-a-scalable-ci-cd-orchestration-platform/index.yaml` (no match)
