### PR TITLE
fix: render organization URLs as clickable links instead of raw text

### DIFF
--- a/src/components/UserStory.jsx
+++ b/src/components/UserStory.jsx
@@ -42,6 +42,90 @@ const fields = [
   'community_supports',
 ];
 
+const formatField = value => {
+  if (typeof value !== 'string') return value;
+
+  const makeLink = (url, text) => (
+    <a
+      href={url.startsWith('http') ? url : `http://${url}`}
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      {text || url}
+    </a>
+  );
+
+  const markdownMatch = value.match(/\[([^\]]+)\]\((https?:\/\/[^)]+)\)/);
+  if (markdownMatch) {
+    const text = value
+      .replace(/\[([^\]]+)\]\((https?:\/\/[^)]+)\)/, '')
+      .replace(/,?\s*$/, '')
+      .trim();
+    return (
+      <>
+        {text && `${text} `}
+        {makeLink(markdownMatch[2], markdownMatch[1])}
+      </>
+    );
+  }
+
+  const angleRegex = /<(https?:\/\/[^>]+)>/g;
+  const angleUrls = [...value.matchAll(angleRegex)];
+  if (angleUrls.length > 0) {
+    const text = value
+      .replace(/,?\s*(and\s*)?<https?:\/\/[^>]+>;?/g, '')
+      .trim();
+    return (
+      <>
+        {text && `${text} `}
+        {angleUrls.map((match, i) => (
+          <span key={i}>
+            {makeLink(match[1])}
+            {i < angleUrls.length - 1 && ' and '}
+          </span>
+        ))}
+      </>
+    );
+  }
+
+  const quoteSepMatch = value.match(
+    /^(.+?)\s*["""]\s*((?:https?:\/\/|www\.)\S+)$/,
+  );
+  if (quoteSepMatch) {
+    return (
+      <>
+        {quoteSepMatch[1].trim()} {makeLink(quoteSepMatch[2])}
+      </>
+    );
+  }
+
+  const plainHttpMatch = value.match(/^(.*?),?\s*(https?:\/\/\S+?)\/?$/);
+  if (plainHttpMatch && plainHttpMatch[2]) {
+    const text = plainHttpMatch[1].trim();
+    return (
+      <>
+        {text && `${text} `}
+        {makeLink(plainHttpMatch[2])}
+      </>
+    );
+  }
+
+  const domainMatch = value.match(
+    /^(.*?),?\s*((?:www\.)?[\w-]+\.(?:com|org|net|io|nl|pl|id|br|ps|jo|dk|au|fr|de|ch|uk)\/?\S*)$/i,
+  );
+  if (domainMatch && domainMatch[2]) {
+    const text = domainMatch[1].trim();
+    return (
+      <>
+        {text && `${text} `}
+        {makeLink(domainMatch[2])}
+      </>
+    );
+  }
+
+  return value;
+};
+
 const UserStory = ({
   image,
   title,
@@ -92,7 +176,7 @@ const UserStory = ({
                           <strong>{titles[field]}: </strong>
                           {Array.isArray(metadata[field])
                             ? metadata[field].join(', ')
-                            : metadata[field]}
+                            : formatField(String(metadata[field]))}
                         </div>
                       ))}
                   </div>


### PR DESCRIPTION
### Description
Organization URLs in story pages were rendering as raw text instead 
of clickable hyperlinks, affecting 60+ stories across the site.

### Fixes
Fixes #371

### Screen Shots (if any)
<img width="1174" height="142" alt="image" src="https://github.com/user-attachments/assets/c97434f3-f2a4-4bda-9349-e0923c4eb194" />
<img width="1126" height="116" alt="image" src="https://github.com/user-attachments/assets/f8833838-0eed-4aac-ba85-89543f8c34ac" />

## Changes
Added formatField() helper function in UserStory.jsx that handles 
all URL formats found in the dataset:
- Angle brackets: `<https://url.com>`
- Markdown: `[text](https://url.com)`
- Multiple URLs: `<url1> and <url2>`
- Quote separator: `Text " https://url.com`
- Plain URL: `https://url.com`
- Plain domain: `apple.com`

## Testing
Tested on multiple stories including:
- Muzkat (angle brackets)
- Alauda (markdown)
- Amarula Solutions (multiple URLs)
- CloudBees (quote separator)
- IAM Robotics (plain URL)
- Apple (plain domain)

### Submitter checklist
- [x] Descriptive PR title and meaningful summary
- [x] Changes align with project conventions
- [x] No unrelated changes included
- [ ] Documentation updated (if needed)

### Additional Context
<!-- Any extra information reviewers should know -->
