### PR TITLE
Fixes the search bar shortcut hint to adapt dynamically based on the user’s platform instead of always displaying `Ctrl + K`.

### DIFF
--- a/src/components/SearchContainer.jsx
+++ b/src/components/SearchContainer.jsx
@@ -15,7 +15,9 @@ class Search extends Component {
   };
 
   componentDidMount() {
+      if (typeof window !== 'undefined') {
     document.addEventListener('keydown', this.handleKeyDown);
+  }
     const { allUserStory } = this.props;
     try {
       const stories = allUserStory.nodes.map(story => ({
@@ -92,8 +94,29 @@ class Search extends Component {
     return new Date(dateString).toLocaleDateString(undefined, options);
   };
 
+getShortcutHint = () => {
+  if (typeof navigator === 'undefined') return '';
+
+  const userAgent = navigator.userAgent;
+
+  // Detect mobile (ALL devices)
+  if (/Android|iPhone|iPad|iPod/i.test(userAgent)) {
+    return '';
+  }
+
+  // Mac
+  if (/Mac/i.test(userAgent)) {
+    return '⌘ + K';
+  }
+
+  // Windows/Linux
+  return 'Ctrl + K';
+};
+
+
   render() {
     const { searchResults, searchQuery, isLoading, isError } = this.state;
+    const shortcut = this.getShortcutHint();
 
     if (isLoading) {
       return <div className="text-center p-4">Loading search...</div>;
@@ -116,7 +139,11 @@ class Search extends Component {
                   className="form-control form-control-lg"
                   value={searchQuery}
                   onChange={this.searchData}
-                  placeholder="[Ctrl+k] Search user stories..."
+                  placeholder={
+                 shortcut
+                 ? `[${shortcut}] Search user stories...`
+                 : 'Search user stories...'
+                }
                   ref={this.searchRef}
                 />
                 <span className="input-group-text">


### PR DESCRIPTION

This behavior is inconsistent across platforms:
- macOS users expect `⌘ + K`
- Mobile users should not see any keyboard shortcut
- Linux/Windows users expect `Ctrl + K`

---

## ✅ Solution
Implemented platform-aware shortcut detection using `navigator.userAgent`:

- **macOS** → `⌘ + K`
- **Windows/Linux** → `Ctrl + K`
- **Mobile devices (Android/iOS)** → No shortcut displayed

The placeholder is now dynamically rendered based on the detected platform.

---

## 🧠 Implementation Details
- Added a helper function `getShortcutHint()` inside the `Search` component
- Used regex-based detection for platform identification
- Updated the input `placeholder` dynamically using the detected shortcut
- Ensured safe execution by checking browser environment (`typeof navigator !== 'undefined'`)

---

## 🧪 Testing
- Verified on:
  - Windows (Chrome) → `Ctrl + K`
  - Mobile (DevTools simulation) → No shortcut shown
  - macOS logic handled via userAgent detection
---

## 🔗 Related Issue
Fixes #363