### PR TITLE
Fixes Devices Searchbar Issue

### DIFF
--- a/src/components/SearchContainer.jsx
+++ b/src/components/SearchContainer.jsx
@@ -105,6 +105,24 @@ class Search extends Component {
       );
     }
 
+    const platform = navigator.platform.toUpperCase();
+    const useCmdKey =
+      platform.indexOf('MAC') >= 0 ||
+      platform === 'IPHONE' ||
+      platform === 'IPAD';
+    const isMobile =
+      platform === 'IPHONE' ||
+      platform === 'IPAD' ||
+      /Android/i.test(navigator.userAgent);
+
+    let placeholder;
+    if (isMobile) {
+      placeholder = 'Search user stories...';
+    } else {
+      const shortcut = useCmdKey ? '⌘ + K' : 'Ctrl + K';
+      placeholder = `[${shortcut}] Search user stories...`;
+    }
+
     return (
       <div className="container py-4 search-container">
         <form onSubmit={this.handleSubmit} className="mb-4">
@@ -116,7 +134,7 @@ class Search extends Component {
                   className="form-control form-control-lg"
                   value={searchQuery}
                   onChange={this.searchData}
-                  placeholder="[Ctrl+k] Search user stories..."
+                  placeholder={placeholder}
                   ref={this.searchRef}
                 />
                 <span className="input-group-text">


### PR DESCRIPTION
### Description
This PR updates the search bar placeholder to display platform-specific keyboard shortcuts and improves UX on mobile devices.

On macOS: shows ⌘ + K
On Windows/Linux: shows Ctrl + K
On mobile devices (iPhone, iPad, Android): hides the shortcut hint and displays only Search user stories...

### Fixes
Fixes issue #363 

### Screen Shots 
on MacOS:
<img width="1460" height="863" alt="Screenshot 2026-03-22 at 5 23 20 PM" src="https://github.com/user-attachments/assets/691b382b-350a-4d57-8b62-9323b2ab322b" />


### Submitter checklist

- [x] Descriptive PR title and meaningful summary
- [x] Changes align with project conventions
- [x] No unrelated changes included
- [x] Documentation updated (if needed)