### PR TITLE
Add PropTypes validation to UserStoryCard component

### DIFF
--- a/src/components/UserStoryCard.jsx
+++ b/src/components/UserStoryCard.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { Link } from 'gatsby';
 import { GatsbyImage, getImage } from 'gatsby-plugin-image';
 import * as styles from './UserStoryCard.module.css';
@@ -30,5 +31,16 @@ function UserStoryCard({ slug, image, title, date, tag_line }) {
     </div>
   );
 }
+
+UserStoryCard.displayName = 'UserStoryCard';
+UserStoryCard.propTypes = {
+  slug: PropTypes.string.isRequired,
+  image: PropTypes.shape({
+    childImageSharp: PropTypes.object,
+  }),
+  title: PropTypes.string.isRequired,
+  date: PropTypes.string.isRequired,
+  tag_line: PropTypes.string,
+};
 
 export default UserStoryCard;


### PR DESCRIPTION
### Description
Added PropTypes validation to the UserStoryCard component to improve type safety and provide better developer warnings during development.

### Fixes
<!-- Fixes #123 (issue number) -->

### Screen Shots (if any)
<!-- N/A - No visual changes -->

### Submitter checklist
- [x] Descriptive PR title and meaningful summary
- [x] Changes align with project conventions
- [x] No unrelated changes included
- [x] Documentation updated (if needed)

### Additional Context
Imported the `prop-types` package and defined PropTypes for the UserStoryCard component props.
