### PR TITLE
reduced the text size of story details main story title

### DIFF
--- a/src/components/UserStory.jsx
+++ b/src/components/UserStory.jsx
@@ -64,7 +64,7 @@ const UserStory = ({
       <div className="row">
         <div className="col">
           <div className="container pb-2">
-            <h1 className="textcolor">{tag_line}</h1>
+            <h1 className={`textcolor ${styles.tagline}`}>{tag_line}</h1>
           </div>
 
           <div className="container pt-2 pb-2">

--- a/src/components/UserStory.module.css
+++ b/src/components/UserStory.module.css
@@ -158,3 +158,24 @@
     max-width: 200px;
   }
 }
+
+.tagline {
+  font-size: 2.75rem;
+  font-weight: 700;
+  line-height: 1.2;
+  margin-bottom: 1.5rem;
+  transition: font-size 0.3s ease;
+}
+
+@media (max-width: 768px) {
+  .tagline {
+    font-size: 1.85rem;
+    margin-bottom: 1rem;
+  }
+}
+
+@media (max-width: 480px) {
+  .tagline {
+    font-size: 1.5rem;
+  }
+}


### PR DESCRIPTION
# [UI/UX] Optimize Mobile Typography Scale for Story Detail Pages

## Description
The current hero section on the Story detail pages (such as `/user-story/jenkins-backbone-of-continuous-integration/`) features a title font size that is disproportionately large for mobile viewports. This results in a visually sparse and unbalanced layout that pushes critical information—like author attribution and the start of the story—below the fold.

This PR redesigns the typography scaling for the `<h1>` heading using responsive units/media queries. These changes improve the visual hierarchy and ensure a more engaging layout that makes a stronger first impression on mobile devices, including the Google Pixel.

## Fixes
Fixes #386 

## Screen Shots
<img width="417" height="801" alt="issue-fixed" src="https://github.com/user-attachments/assets/08b7c700-330a-43e8-9d6c-d3349989f1a8" />


## Submitter checklist
- [x] Descriptive PR title and meaningful summary
- [x] Changes align with project conventions
- [x] No unrelated changes included
- [x] Documentation updated (if needed)

## Additional Context
Full problem description and current behavior are detailed in the linked issue. This improvement specifically targets mobile readability without affecting the desktop layout or existing site functionality.