### PR TITLE
GSoC 2026: add schema validator using ajv for validating stories yaml files.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "name": "stories",
       "version": "0.0.0",
       "dependencies": {
+        "ajv": "^8.20.0",
+        "ajv-formats": "^3.0.1",
         "js-yaml": "^4.2.0",
         "react": "^19.2.6",
         "react-dom": "^19.2.6",
@@ -1514,18 +1516,36 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.15.0",
-      "dev": true,
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "license": "MIT",
       "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
       }
     },
     "node_modules/ansi-regex": {
@@ -2104,6 +2124,30 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint/node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/eslint/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/espree": {
       "version": "11.2.0",
       "dev": true,
@@ -2170,11 +2214,12 @@
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "dev": true,
       "license": "MIT"
     },
@@ -2182,6 +2227,22 @@
       "version": "2.0.6",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -2242,14 +2303,16 @@
       "license": "ISC"
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -2679,8 +2742,9 @@
       "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "dev": true,
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
@@ -3735,6 +3799,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/requires-port": {
       "version": "1.0.0",
       "license": "MIT"
@@ -4097,6 +4170,8 @@
     },
     "node_modules/uri-js": {
       "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "format:check": "prettier . --check"
   },
   "dependencies": {
+    "ajv": "^8.20.0",
+    "ajv-formats": "^3.0.1",
     "js-yaml": "^4.2.0",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "format": "prettier . --write",
-    "format:check": "prettier . --check"
+    "format:check": "prettier . --check",
+    "validate:stories": "node src/story-schema/schema-validate.js"
   },
   "dependencies": {
     "ajv": "^8.20.0",

--- a/src/story-schema/schema-validate.js
+++ b/src/story-schema/schema-validate.js
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import path from 'path';
+import { fileURLToPath } from 'url';
 import { load } from 'js-yaml';
 import Ajv from 'ajv';
 import addFormats from 'ajv-formats';
@@ -23,7 +24,8 @@ function getYamlFiles(dir) {
   return files;
 }
 
-const files = getYamlFiles('src/user-story');
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const files = getYamlFiles(path.resolve(__dirname, '../../src/user-story'));
 let failed = 0;
 
 for (const file of files) {

--- a/src/story-schema/schema-validate.js
+++ b/src/story-schema/schema-validate.js
@@ -1,0 +1,54 @@
+import fs from 'fs';
+import path from 'path';
+import { load } from 'js-yaml';
+import Ajv from 'ajv';
+import addFormats from 'ajv-formats';
+import schema from './schema.js';
+import process from 'process';
+
+const ajv = new Ajv({ allErrors: true, strict: false });
+addFormats(ajv);
+const validate = ajv.compile(schema);
+
+function getYamlFiles(dir) {
+  let files = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files = files.concat(getYamlFiles(fullPath));
+    } else if (entry.name.endsWith('.yaml')) {
+      files.push(fullPath);
+    }
+  }
+  return files;
+}
+
+const files = getYamlFiles('src/user-story');
+let failed = 0;
+
+for (const file of files) {
+  const doc = load(fs.readFileSync(file, 'utf8'));
+
+  if (doc.date instanceof Date) {
+    doc.date = doc.date.toISOString();
+  }
+
+  const valid = validate(doc);
+
+  if (!valid) {
+    console.log(`\n ${file}`);
+    for (const err of validate.errors) {
+      if (err.keyword === 'additionalProperties') {
+        console.log(
+          `  Unknown field: "${err.instancePath}/${err.params.additionalProperty}"`,
+        );
+      } else {
+        console.log(`  ${err.instancePath || '/'} ${err.message}`);
+      }
+    }
+    failed++;
+  }
+}
+
+console.log(`\n${files.length - failed} passed, ${failed} failed`);
+process.exit(failed ? 1 : 0);

--- a/src/story-schema/schema.js
+++ b/src/story-schema/schema.js
@@ -5,14 +5,12 @@ export default {
     'date',
     'authored_by',
     'body_content',
-    'image',
-    'post_name',
   ],
   additionalProperties: false,
 
   properties: {
     title: { type: 'string' },
-    date: { type: 'string' },
+    date: { type: 'string', format: 'date-time' },
     authored_by: { type: 'string' },
     post_name: { type: 'string' },
     tag_line: { type: 'string' },

--- a/src/story-schema/schema.js
+++ b/src/story-schema/schema.js
@@ -1,0 +1,83 @@
+export default {
+  type: 'object',
+  required: [
+    'title',
+    'date',
+    'authored_by',
+    'body_content',
+    'image',
+    'post_name',
+  ],
+  additionalProperties: false,
+
+  properties: {
+    title: { type: 'string' },
+    date: { type: 'string' },
+    authored_by: { type: 'string' },
+    post_name: { type: 'string' },
+    tag_line: { type: 'string' },
+    image: { type: 'string' },
+
+    map: {
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        authored_by: { type: 'string' },
+        location: { type: 'string' },
+        industries: { type: 'array', items: { type: 'string' } },
+        geojson: { type: 'string' },
+      },
+    },
+
+    metadata: {
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        title: { type: 'string' },
+        organization: { type: 'string' },
+        company: { type: 'string' },
+        company_website: {
+          oneOf: [
+            { type: 'string', format: 'uri' },
+            { type: 'array', items: { type: 'string', format: 'uri' } },
+          ],
+        },
+        teams: { type: 'array', items: { type: 'string' } },
+        team_members: { type: 'array', items: { type: 'string' } },
+        project_website: { type: 'string', format: 'uri' },
+        project_funding: { type: 'string' },
+        funded_by: { type: 'string' },
+        summary: { type: 'string' },
+        industries: { type: 'array', items: { type: 'string' } },
+        programming_languages: { type: 'array', items: { type: 'string' } },
+        platforms: { type: 'array', items: { type: 'string' } },
+        version_control_systems: { type: 'array', items: { type: 'string' } },
+        build_tools: { type: 'array', items: { type: 'string' } },
+        plugins: { type: 'array', items: { type: 'string' } },
+        community_supports: { type: 'array', items: { type: 'string' } },
+      },
+    },
+
+    body_content: {
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        title: { type: 'string' },
+        paragraphs: { type: 'array', items: { type: 'string' } },
+      },
+    },
+
+    quotes: {
+      type: 'array',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+          from: { type: 'string' },
+          content: { type: 'string' },
+          image: { type: 'string' },
+        },
+      },
+    },
+  },
+};

--- a/src/story-schema/schema.js
+++ b/src/story-schema/schema.js
@@ -5,6 +5,7 @@ export default {
     'date',
     'authored_by',
     'body_content',
+    'metadata'
   ],
   additionalProperties: false,
 


### PR DESCRIPTION
### Description
<!-- please provide a clear and concise description of the PR. -->
This Pull request introduces YAML schema validation using ajv and ajv formats. This validator checks for field name, types, etc

files changes: 
- package.json and package-lock.json dependency addition
- src/story-schema/schema.js && src/story-schema/schema-validate.js 

next: 
- we need to decide where we have to place the files i.e. schema.js and schema-validate, we have following options
       - under /scripts
       - under/utils
       - or in current place
      
- we also need to decide about it's usage
       - add this in CI right now or later
       - add this in package.json as scripts:  "node --path--"
       - add this as a pre-commit hook ? 