### PR TITLE
chore(Jenkinsfile/CI) utilizes container agents instead of VM agents

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,7 @@
 // Do not trigger daily if not on the principal branch (e.g. not on PR, not on other branches, not on tags)
-String cronPattern = env.BRANCH_IS_PRIMARY ? '@daily' : ''
+final String cronPattern = env.BRANCH_IS_PRIMARY ? '@daily' : ''
+// infra.ci.jenkins.io defaults to arm64 VM agents (due to Gastby memory requirements) while ci.jenkins.io has the default spot amd64 used by Java builds.
+final String agentLabel = infra.isInfra() ? 'linux-arm64-docker' : 'maven-25'
 
 pipeline {
   triggers {
@@ -13,7 +15,7 @@ pipeline {
   }
 
   agent {
-    label 'linux-arm64-docker || arm64linux'
+    label agentLabel
   }
 
   environment {
@@ -21,7 +23,7 @@ pipeline {
     TZ = "UTC"
     // Amount of available vCPUs, to avoid OOM - https://www.gatsbyjs.com/docs/how-to/performance/resolving-out-of-memory-issues/#try-reducing-the-number-of-cores
     // https://github.com/jenkins-infra/jenkins-infra/tree/production/hieradata/clients/controller.ci.jenkins.io.yaml#L327
-    GATSBY_CPU_COUNT = "4"
+    GATSBY_CPU_COUNT = '2'
     // Added the below to fix permissions issue with the cache
     GATSBY_CACHE_DIR = "${env.WORKSPACE}/.gatsby-cache"
     GATSBY_INTERNAL_CACHE_DIR = "${env.WORKSPACE}/.cache"


### PR DESCRIPTION
Following https://github.com/jenkins-infra/helpdesk/issues/5202#issuecomment-4887424379, let's use container agents on ci.jenkins.io.

Same as https://github.com/jenkins-infra/plugin-site/pull/2563 (gastby requiring VM on infra.ci)